### PR TITLE
Memory fix using batch threading

### DIFF
--- a/common/config.yaml
+++ b/common/config.yaml
@@ -14,6 +14,7 @@ model_path_out:                 model.plk
 result_path_out:                output
 results_size:                   10
 emails_threshold:               1000
+batch_threading_size:           20
 detectors:
     DateTimezoneDetector:       1
     MessageIdDetectorOne:       1

--- a/common/memtest.py
+++ b/common/memtest.py
@@ -27,6 +27,5 @@ class MemTracker(object):
         h = MemTracker.heapy_instance.heap()
         with open(MemTracker.log_file_path, "a") as f:
             f.write("Memory statistics for '" + section_name + "':\n")
-            for i in range(len(h)):
-                f.write(str(h[i]) + "\n")
+            f.write(str(h) + "\n")
             f.write("\n")


### PR DESCRIPTION
The memory issue found is that we held all feature generators in memory (which in turn has references to the inboxes and sender profiles respective to those feature generators), which basically caused us to hold every existing email in memory at once. To combat this, batch threading has been implemented to make sure that no more than batch_threading_size feature generators at once can exist in memory (default is 30). This means that only 30 users inboxes/sender profiles can exist in memory at a given time and are executed by our thread pool at a time.
