### PR TITLE
Memory tracking

### DIFF
--- a/common/classify.py
+++ b/common/classify.py
@@ -11,6 +11,7 @@ from sklearn.utils import shuffle
 from sklearn.externals import joblib
 from memtest import MemTracker
 import datetime as dt
+import logging
 
 PATH_IND = 0
 LEGIT_IND = 1
@@ -18,6 +19,8 @@ PROBA_IND = 2
 TEST_IND = 3
 MESS_ID_IND = 4
 TOTAL_SIZE = 5
+
+progress_logger = logging.getLogger('spear_phishing.progress')
 
 class Classify:
 
@@ -128,7 +131,7 @@ class Classify:
         res_sorted = results[results[:,PROBA_IND].argsort()][::-1]
         self.num_phish, self.test_size = self.calc_phish(res_sorted)
         output = self.filter_output(res_sorted)
-        progress_logger.info(pp.pprint(output))
+        progress_logger.info(pp.pformat(output))
         self.d_name_per_feat = self.parse_feature_names()
         self.pretty_print(output[0], "low_volume")
         self.pretty_print(output[1], "high_volume")

--- a/common/classify.py
+++ b/common/classify.py
@@ -62,21 +62,21 @@ class Classify:
         self.X = X
         self.Y = Y
         self.data_size = len(X)
-        print("Finished concatenating training matrix.")
+        progress_logger.info("Finished concatenating training matrix.")
 
     def cross_validate(self):
         validate_clf = linear_model.LogisticRegression(class_weight=self.weights)
         self.validation_acc = cross_validation.cross_val_score(validate_clf, self.X, self.Y.ravel(), cv=5)
-        print("Validation Accuracy: {}".format(self.validation_acc.mean()))
+        progress_logger.info("Validation Accuracy: {}".format(self.validation_acc.mean()))
 
     def train_clf(self):
         self.clf.fit(self.X, self.Y.ravel())
-        print("Finished training classifier.")
+        progress_logger.info("Finished training classifier.")
         self.clf_coef = self.clf.coef_[0]
 
     def serialize_clf(self):
         joblib.dump(self.clf, self.serial_to_path)
-        print("Finished serializing.")
+        progress_logger.info("Finished serializing.")
         
     def clean_all(self):
         try:
@@ -128,7 +128,7 @@ class Classify:
         res_sorted = results[results[:,PROBA_IND].argsort()][::-1]
         self.num_phish, self.test_size = self.calc_phish(res_sorted)
         output = self.filter_output(res_sorted)
-        pp.pprint(output)
+        progress_logger.info(pp.pprint(output))
         self.d_name_per_feat = self.parse_feature_names()
         self.pretty_print(output[0], "low_volume")
         self.pretty_print(output[1], "high_volume")

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -1,7 +1,7 @@
 #Configuration file for PhishDetector
 
 #Data and Test Matrix Configurations
-root_dir:                       ../broScripts/output
+root_dir:                       regular
 sender_profile_percentage:      0.1
 data_matrix_percentage:         0.2
 test_matrix_percentage:         0.7
@@ -31,7 +31,8 @@ parallel:                       0
 num_threads:                    5
 
 #Memory Logging Settings
-memlog_minute_frequency:        60
+memlog_gen_features_frequency:  60
+memlog_classify_frequency:      1
 
 #Do not modify unless you are certain what you are doing
 regular_filename:               legit_emails.log

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -1,7 +1,7 @@
 #Configuration file for PhishDetector
 
 #Data and Test Matrix Configurations
-root_dir:                       ../broScripts/output
+root_dir:                       regular
 sender_profile_percentage:      0.1
 data_matrix_percentage:         0.2
 test_matrix_percentage:         0.7

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -27,7 +27,7 @@ detectors:
     DateFormatDetector:         1
 
 #Parallel Settings
-parallel:                       1
+parallel:                       0
 num_threads:                    5
 
 #Do not modify unless you are certain what you are doing

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -30,6 +30,9 @@ detectors:
 parallel:                       0
 num_threads:                    5
 
+#Memory Logging Settings
+memlog_minute_frequency:        60
+
 #Do not modify unless you are certain what you are doing
 regular_filename:               legit_emails.log
 phish_filename:                 phish_emails.log

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -1,7 +1,7 @@
 #Configuration file for PhishDetector
 
 #Data and Test Matrix Configurations
-root_dir:                       regular
+root_dir:                       ../broScripts/output
 sender_profile_percentage:      0.1
 data_matrix_percentage:         0.2
 test_matrix_percentage:         0.7

--- a/common/memtest.py
+++ b/common/memtest.py
@@ -1,5 +1,6 @@
 import os
 from guppy import hpy
+import datetime as dt
 
 class MemTracker(object):
     log_file_path = None
@@ -13,7 +14,8 @@ class MemTracker(object):
         if os.path.exists(MemTracker.log_file_path):
             os.remove(MemTracker.log_file_path)
         with open(MemTracker.log_file_path, "a") as f:
-            f.write("Beggining memory tracking.\n\n")
+            now = dt.datetime.now()
+            f.write("Relative heap set. Ready for memory tracking (TimeStamp: " + str(now) + ")\n\n")
 
 
     @classmethod
@@ -24,8 +26,16 @@ class MemTracker(object):
             MemTracker.heapy_instance = hpy()
             MemTracker.heapy_instance.setrelheap()
         
-        h = MemTracker.heapy_instance.heap()
         with open(MemTracker.log_file_path, "a") as f:
-            f.write("Memory statistics for '" + section_name + "':\n")
-            f.write(str(h) + "\n")
-            f.write("\n")
+            f.write("Memory statistics for '" + section_name + "':\n\n")
+            start = dt.datetime.now()
+            f.write("Starting TimeStamp: " + str(start))
+            f.write("\n\n")
+            h = MemTracker.heapy_instance.heap()
+            f.write(str(h))
+            f.write("\n\n")
+            end = dt.datetime.now()
+            f.write("Ending TimeStamp: " + str(end))
+            delta = end - start
+            f.write("\nProfiling took " + str(delta.seconds) + " seconds.")
+            f.write("\n\n")

--- a/common/phish_detector.py
+++ b/common/phish_detector.py
@@ -4,12 +4,14 @@ import time
 import yaml
 import feature_classes as fc
 import traceback
+import datetime as dt
 from classify import Classify  
 
 from multiprocessing import Pool
 from generate_features import FeatureGenerator
 from lookup import Lookup
 from memtest import MemTracker
+
 
 class PhishDetector(object):
 
@@ -125,6 +127,7 @@ class PhishDetector(object):
             'results_size',
             'parallel',
             'num_threads',
+            'memlog_minute_frequency'
         ]
 
         try:
@@ -190,10 +193,14 @@ class PhishDetector(object):
         else:
             print('Generating features serially...')
             dir_count = 0
-            log_mem_limit = 100000
+            end_of_last_memory_track = dt.datetime.now()
             for directory in dir_to_generate:
-                if (dir_count + 1) % log_mem_limit == 0:
+                now = dt.datetime.now()
+                time_elapsed = now - end_of_last_memory_track
+                minutes_elapsed = time_elapsed.seconds / 60.0
+                if minutes_elapsed > self.memlog_minute_frequency: #15 seconds
                     MemTracker.logMemory("After generating features for " + str(dir_count + 1) + " senders")
+                    end_of_last_memory_track = dt.datetime.now()
                 feature_generator = self.prep_features(directory)
                 feature_generator.run()
                 dir_count += 1

--- a/common/phish_detector.py
+++ b/common/phish_detector.py
@@ -127,7 +127,8 @@ class PhishDetector(object):
             'results_size',
             'parallel',
             'num_threads',
-            'memlog_minute_frequency'
+            'memlog_gen_features_frequency',
+            'memlog_classify_frequency'
         ]
 
         try:
@@ -198,7 +199,7 @@ class PhishDetector(object):
                 now = dt.datetime.now()
                 time_elapsed = now - end_of_last_memory_track
                 minutes_elapsed = time_elapsed.seconds / 60.0
-                if minutes_elapsed > self.memlog_minute_frequency: #15 seconds
+                if minutes_elapsed > self.memlog_gen_features_frequency:
                     MemTracker.logMemory("After generating features for " + str(dir_count + 1) + " senders")
                     end_of_last_memory_track = dt.datetime.now()
                 feature_generator = self.prep_features(directory)
@@ -206,7 +207,7 @@ class PhishDetector(object):
                 dir_count += 1
 
     def generate_model_output(self):
-        self.classifier = Classify(self.weights, self.root_dir, self.emails_threshold, self.results_size, results_dir=self.result_path_out, serial_path=self.model_path_out)
+        self.classifier = Classify(self.weights, self.root_dir, self.emails_threshold, self.results_size, results_dir=self.result_path_out, serial_path=self.model_path_out, memlog_freq=self.memlog_classify_frequency)
         self.classifier.generate_training()
         self.classifier.train_clf()
         self.classifier.cross_validate()


### PR DESCRIPTION
Three new features:
- Adds timestamps and durations to all memory profiles.
- Profiles memory during feature generator loop every 60 minutes (can be changed via memlog_gen_features_frequency in config.yaml).
- Profiles memory during loop of Classify.py's test_and_report every minute (can be changed via memlog_classify_frequency in config.yaml)

Currently all of this is logged to common/memory.log. Probably not the right file to log to, but I'll log it to the public folder once it's set to be created in the code.
