### PR TITLE
Added time-based logging

### DIFF
--- a/common/classify.py
+++ b/common/classify.py
@@ -41,9 +41,17 @@ class Classify:
         X = None
         Y = None
         found_training_file = False
+        logging_interval = 60 # TODO(matthew): Move to config.yaml
         progress_logger.info("Starting to build training matrix.")
         start_time = time.time()
-        for root, dirs, files in os.walk(self.email_path): 
+        last_logged_time = start_time
+        num_senders_completed = 0
+        for root, dirs, files in os.walk(self.email_path):
+            curr_time = time.time()
+            if (curr_time - last_logged_time) > logging_interval * 60:
+                progress_logger.info('Exploring directory #{}'.format(num_senders_completed))
+                progress_logger.info('Building training matrix has run for {} minutes'.format(int((curr_time - start_time) / 60)))
+                last_logged_time = curr_time
             if 'training.mat' in files:
                 found_training_file = True
                 path = os.path.join(root, "training.mat")
@@ -60,6 +68,7 @@ class Classify:
                     continue
                 X = np.concatenate((X, part_X), axis=0)
                 Y = np.concatenate((Y, part_Y), axis=0)
+            num_senders_completed += 1
         if not found_training_file:
             raise RuntimeError("Cannot find 'training.mat' files.")
         if X is None:
@@ -71,7 +80,7 @@ class Classify:
         self.data_size = len(X)
         end_time = time.time()
         min_elapsed, sec_elapsed = int((end_time - start_time) / 60), int((end_time - start_time) % 60)
-        progress_logger.info("Finished concatenating training matrix in {} minutes, {} seconds.".format(min_elapsed, sec_elapsed))
+        progress_logger.info("Finished concatenating training matrix in {} minutes, {} seconds. {} directories seen.".format(min_elapsed, sec_elapsed, num_senders_completed))
 
     def cross_validate(self):
         progress_logger.info("Starting cross validation.")
@@ -118,7 +127,7 @@ class Classify:
         for root, dirs, files in os.walk(self.email_path):
             curr_time = time.time()
             if (curr_time - last_logged_time) > logging_interval * 60:
-                progress_logger.info('Exploring directory: {}'.format(root))
+                progress_logger.info('Exploring directory #{}'.format(num_senders_completed))
                 progress_logger.info('Testing has run for {} minutes'.format(int((curr_time - start_time) / 60)))
                 last_logged_time = curr_time
             if self.memlog_freq >= 0:
@@ -156,7 +165,7 @@ class Classify:
         self.write_summary_output(output)
         end_time = time.time()
         min_elapsed, sec_elapsed = int((end_time - start_time) / 60), int((end_time - start_time) % 60)
-        progress_logger.info("Finished testing on data in {} minutes, {} seconds".format(min_elapsed, sec_elapsed))
+        progress_logger.info("Finished testing on data in {} minutes, {} seconds. {} directories tested.".format(min_elapsed, sec_elapsed, num_senders_completed))
     
     def write_as_matfile(self, results):
         # Don't write the test_indx, only [path, indx, phish_prob, message_id]

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -33,3 +33,6 @@ num_threads:                    5
 #Do not modify unless you are certain what you are doing
 regular_filename:               legit_emails.log
 phish_filename:                 phish_emails.log
+
+#Progress Configurations
+logging_interval:               60

--- a/common/phish_detector.py
+++ b/common/phish_detector.py
@@ -216,7 +216,7 @@ class PhishDetector(object):
                 dir_count += 1
                 curr_time = time.time()
                 if (curr_time - last_logged_time) > self.logging_interval * 60:
-                    progress_logger.info('Generating feature #{}'.format(dir_count))
+                    progress_logger.info('Processing directory #{} of {}'.format(dir_count, len(dir_to_generate)))
                     progress_logger.info('Feature generation has run for {} minutes'.format(int((curr_time - start_time) / 60)))
                     last_logged_time = curr_time
                 now = dt.datetime.now()


### PR DESCRIPTION
### What is this?

For the feature generation and classification process, the running time of the entire pipeline scales linearly with the amount of data we have. As a sanity check to verify that the pipeline is still running, this PR adds logging to these processes at fixed time intervals (currently set to 60 minutes) so that the user is guaranteed to receive a health check at this fixed time interval if the pipeline is still in progress.
### How do we know this works?

Will test to see the time-based logging is performing as expected on a larger pre-generated set of emails. Will not merge until after https://github.com/mikeaboody/phishing-research/pull/36 gets merged, since we want to test on the serial process instead of the parallel one.

to: @mikeaboody @nexusapoorvacus 
cc: @davidwagner 
