### PR TITLE
Stop logging confidential info (output directory names) in progress.log

### DIFF
--- a/broScripts/parse_pcap.py
+++ b/broScripts/parse_pcap.py
@@ -108,6 +108,7 @@ try:
 
     # Generating legit emails
     senders_seen = open(SENDERS_FILE, 'a+')
+    dir_num = 0
     for filename in glob.glob(PCAP_DIRECTORY + '/*.pcap'):
         try:
             call(['bro', '-r', filename, '-b', BRO_SCRIPT_PATH])
@@ -152,7 +153,8 @@ try:
                         name = 'noname'
                         sender_dir = "{}/{}/{}".format(OUTPUT_DIRECTORY, name, address)
                     if not os.path.exists(sender_dir):
-                        progress_logger.info('Creating Output Directory for {}'.format(name))
+                        dir_num += 1
+                        progress_logger.info('Creating Directory #{}'.format(dir_num))
                         try:
                             os.makedirs(sender_dir)
                             total_senders += 1

--- a/common/classify.py
+++ b/common/classify.py
@@ -158,7 +158,6 @@ class Classify:
         res_sorted = results[results[:,PROBA_IND].argsort()][::-1]
         self.num_phish, self.test_size = self.calc_phish(res_sorted)
         output = self.filter_output(res_sorted)
-        progress_logger.info(pp.pformat(output))
         self.d_name_per_feat = self.parse_feature_names()
         self.pretty_print(output[0], "low_volume")
         self.pretty_print(output[1], "high_volume")

--- a/common/generate_features.py
+++ b/common/generate_features.py
@@ -42,6 +42,8 @@ defined in detector.py.
 """
 
 class FeatureGenerator(object):
+    DIR_NUM = 0
+
     def __init__(self,
                  output_directory,
                  filename,
@@ -177,5 +179,5 @@ class FeatureGenerator(object):
             test_path = os.path.join(self.output_directory, 'test.mat')
             sio.savemat(test_path, test_dict)
             
-        
-        progress_logger.info(self.output_directory + " generated.")
+        FeatureGenerator.DIR_NUM += 1
+        progress_logger.info('Data and features generated for directory #{}'.format(FeatureGenerator.DIR_NUM))


### PR DESCRIPTION
Fix for https://github.com/mikeaboody/phishing-research/issues/43. Note that it's still possible for sensitive info to show up in the debug logs, but I think that's unavoidable if we want to have any useful information about where to look for debugging. 

Main changes:
1) Instead of logging the directories that are being created/parsed, we just log the corresponding directory number.
2) We don't log the final output of the result. Note that this information is already being written to a file, so Vern will still have access to this (he just won't send us that file).
