### PR TITLE
Only log output every 60 seconds in parse_pcap

### DIFF
--- a/broScripts/parse_pcap.py
+++ b/broScripts/parse_pcap.py
@@ -5,6 +5,7 @@ import os
 import random
 import re
 from subprocess import call
+import time
 
 import numpy as np
 
@@ -97,6 +98,8 @@ def parseLine(line):
         line = line[endParen+2:]
 try:
     progress_logger.info("======== Starting Pcap Parsing Phase ========")
+    start_time = time.time()
+    last_logged_time = start_time
     clean_all()
     try:
         if not os.path.exists(OUTPUT_DIRECTORY):
@@ -154,7 +157,10 @@ try:
                         sender_dir = "{}/{}/{}".format(OUTPUT_DIRECTORY, name, address)
                     if not os.path.exists(sender_dir):
                         dir_num += 1
-                        progress_logger.info('Creating Directory #{}'.format(dir_num))
+                        curr_time = time.time()
+                        if curr_time - last_logged_time > 60: # Only log every 60 seconds.
+                            last_logged_time = curr_time
+                            progress_logger.info('Creating Directory #{}'.format(dir_num))
                         try:
                             os.makedirs(sender_dir)
                             total_senders += 1
@@ -172,7 +178,9 @@ try:
         except Exception as e:
             debug_logger.exception("Unable to move {}".format(bro_filename))
         total_pcaps += 1
-    progress_logger.info('Done.  Created #{} directories.'.format(dir_num))
+    end_time = time.time()
+    min_elapsed, sec_elapsed = int((end_time - start_time) / 60), int((end_time - start_time) % 60)
+    progress_logger.info('Done. Created {} directories in {} minutes, {} seconds.'.format(dir_num, min_elapsed, sec_elapsed))
     senders_seen.close()
 
     os.system('shuf {} > /dev/null'.format(SENDERS_FILE))

--- a/common/generate_features.py
+++ b/common/generate_features.py
@@ -42,8 +42,6 @@ defined in detector.py.
 """
 
 class FeatureGenerator(object):
-    DIR_NUM = 0
-
     def __init__(self,
                  output_directory,
                  filename,
@@ -178,6 +176,3 @@ class FeatureGenerator(object):
 
             test_path = os.path.join(self.output_directory, 'test.mat')
             sio.savemat(test_path, test_dict)
-            
-        FeatureGenerator.DIR_NUM += 1
-        progress_logger.info('Data and features generated for directory #{}'.format(FeatureGenerator.DIR_NUM))

--- a/common/phish_detector.py
+++ b/common/phish_detector.py
@@ -207,7 +207,7 @@ class PhishDetector(object):
             min_elapsed, sec_elapsed = int((end_time - start_time) / 60), int((end_time - start_time) % 60)
             progress_logger.info('Finished feature generation in {} minutes, {} seconds.'.format(min_elapsed, sec_elapsed))
         else:
-            progress_logger.info('Starting feature generation serially...')
+            progress_logger.info('Starting feature generation serially for {} directories'.format(len(dir_to_generate)))
             start_time = time.time()
             last_logged_time = start_time
             dir_count = 0


### PR DESCRIPTION
### What is this?

Fix for https://github.com/mikeaboody/phishing-research/issues/47. In the pcap-parsing phase, I'm now only logging progress every 60 seconds. I also removed logging completely from `generate_features.py`, since that same information is already being logged here: https://github.com/mikeaboody/phishing-research/blob/master/common/phish_detector.py#L219-L220

to: @nexusapoorvacus @mikeaboody 
cc: @davidwagner 
