### PR TITLE
Name Email Selection

### DIFF
--- a/common/config.yaml
+++ b/common/config.yaml
@@ -5,6 +5,7 @@ root_dir:                       ../broScripts/output
 sender_profile_percentage:      0.1
 data_matrix_percentage:         0.2
 test_matrix_percentage:         0.7
+use_name_in_from:               1
 
 #Model Training and Classification Settings
 weights:

--- a/common/detector.py
+++ b/common/detector.py
@@ -67,6 +67,7 @@ class Detector(object):
 
         Returns the sender stored in msg's From header.
         """
+
         return msg["From"]
 
     def make_phish(self):
@@ -85,3 +86,23 @@ class Detector(object):
         phish['Subject'] = random_msg['Subject'] 
         phish = self.modify_phish(phish, random_msg)
         return phish
+
+# returns apoorva.dornadula@berkeley.edu given "Apoorva Dornadula <apoorva.dornadula@berkeley.edu>"
+def extract_email(from_header):
+    if from_header == None:
+        return None
+    if ("<" in from_header and ">" in from_header):
+        leftBracket = from_header.index("<")
+        rightBracket = from_header.index(">")
+        return from_header[leftBracket+1:rightBracket]
+    return from_header
+
+def extract_name(from_header):
+    if not from_header:
+        return None
+    from_header = from_header.lower()
+    r = re.compile(" *<.*> *")
+    from_header = r.sub("", from_header)
+    r = re.compile("^ +")
+    from_header = r.sub("", from_header)
+    return from_header

--- a/common/detector.py
+++ b/common/detector.py
@@ -7,6 +7,7 @@ class Detector(object):
     __metaclass__ = abc.ABCMeta
     """Length of list returned by classify()."""
     NUM_HEURISTICS = 1
+    USE_NAME = False
 
     def __init__(self, regular_mbox):
         self.inbox = regular_mbox
@@ -67,8 +68,11 @@ class Detector(object):
 
         Returns the sender stored in msg's From header.
         """
-
-        return msg["From"]
+        from_header = msg["From"]
+        if Detector.USE_NAME:
+            return extract_name(from_header)
+        else:
+            return extract_email(from_header)
 
     def make_phish(self):
         """Generates a phishy email."""

--- a/common/feature_classes.py
+++ b/common/feature_classes.py
@@ -192,13 +192,3 @@ class XMailerDetector(Detector):
                 return s
         return False
 
-    def extract_name(self, msg):
-        from_header = msg["From"]
-        if not from_header:
-            return None
-        from_header = from_header.lower()
-        r = re.compile(" *<.*> *")
-        from_header = r.sub("", from_header)
-        r = re.compile("^ +")
-        from_header = r.sub("", from_header)
-        return from_header

--- a/common/message_ID_domain.py
+++ b/common/message_ID_domain.py
@@ -42,7 +42,7 @@ class messageIDDomain_Detector(Detector):
         return mID
         
     def classify(self, phish):
-        sender = self.getEntireEmail(phish["From"])
+        sender = self.getEntireEmail(self.extract_from(phish))
         mID = self.get_endMessageIDDomain(self.get_messageIDDomain(phish))
 
         if sender in self.sender_profile.keys():
@@ -153,7 +153,7 @@ class messageIDDomain_Detector(Detector):
             msg = self.inbox[i]
             # if "List-Unsubscribe" in msg.keys():
             #     continue
-            sender = self.getEntireEmail(msg["From"])
+            sender = self.getEntireEmail(self.extract_from(msg))
             if sender:
                 emails_with_sender += 1
                 mID = self.get_endMessageIDDomain(self.get_messageIDDomain(msg))

--- a/common/message_ID_domain.py
+++ b/common/message_ID_domain.py
@@ -42,7 +42,7 @@ class messageIDDomain_Detector(Detector):
         return mID
         
     def classify(self, phish):
-        sender = self.getEntireEmail(self.extract_from(phish))
+        sender = self.extract_from(phish)
         mID = self.get_endMessageIDDomain(self.get_messageIDDomain(phish))
 
         if sender in self.sender_profile.keys():
@@ -76,16 +76,6 @@ class messageIDDomain_Detector(Detector):
             i = part.index(".")
             return part[i+1:]
         return email[indexAt+1:indexEnd]
-
-    # returns apoorva.dornadula@berkeley.edu given "Apoorva Dornadula <apoorva.dornadula@berkeley.edu>"
-    def getEntireEmail(self, sender):
-        if sender == None:
-            return None
-        if ("<" in sender and ">" in sender):
-            leftBracket = sender.index("<")
-            rightBracket = sender.index(">")
-            return sender[leftBracket+1:rightBracket]
-        return sender
 
     # returns True if FP and email will not be flagged
     def noreplyFP(self, sender, messageID):
@@ -153,7 +143,7 @@ class messageIDDomain_Detector(Detector):
             msg = self.inbox[i]
             # if "List-Unsubscribe" in msg.keys():
             #     continue
-            sender = self.getEntireEmail(self.extract_from(msg))
+            sender = self.extract_from(msg)
             if sender:
                 emails_with_sender += 1
                 mID = self.get_endMessageIDDomain(self.get_messageIDDomain(msg))

--- a/common/phish_detector.py
+++ b/common/phish_detector.py
@@ -9,6 +9,7 @@ import traceback
 import yaml
 
 from classify import Classify
+from detector import Detector
 import feature_classes as fc
 from generate_features import FeatureGenerator
 from lookup import Lookup
@@ -122,6 +123,7 @@ class PhishDetector(object):
             'sender_profile_percentage',
             'data_matrix_percentage',
             'test_matrix_percentage',
+            'use_name_in_from',
             'model_path_out',
             'result_path_out',
             'weights',
@@ -172,6 +174,9 @@ class PhishDetector(object):
 
 
     def generate_features(self):
+        if self.use_name_in_from != 0:
+            Detector.USE_NAME = True
+
         dir_to_generate = []
 
         progress_logger.info('Starting directory aggregation in feature generation.')

--- a/common/received_headers.py
+++ b/common/received_headers.py
@@ -181,13 +181,6 @@ class ReceivedHeadersDetector(Detector):
     def create_sender_profile(self, num_samples):
         self.srp = SenderReceiverProfile(self.inbox, num_samples, self)
 
-# def extract_email(from_header):
-#     if not from_header:
-#         return None
-#     from_header = from_header.lower()
-#     r = re.search("([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)", from_header)
-#     return r.group() if r else from_header
-
 def removeSpaces(s):
     exp = " +$"
     r = re.compile(exp)

--- a/common/received_headers.py
+++ b/common/received_headers.py
@@ -97,7 +97,7 @@ class SenderReceiverProfile(dict):
         self.createReceivedHeaderSequences()
 
     def appendEmail(self, msg):
-        sender = extract_email(self.detector.extract_from(msg))
+        sender = self.detector.extract_from(msg)
         receiver = ""
         if (sender, receiver) not in self:
             self[(sender, receiver)] = SenderReceiverPair(sender, receiver)
@@ -149,7 +149,7 @@ class ReceivedHeadersDetector(Detector):
 
     def classify(self, phish):
         RHList = []
-        sender = extract_email(self.extract_from(phish))
+        sender = self.extract_from(phish)
         receiver = ""
         edit_distances = [0, 1, 2]
         feature_vector = [0 for _ in range(len(edit_distances))]
@@ -181,12 +181,12 @@ class ReceivedHeadersDetector(Detector):
     def create_sender_profile(self, num_samples):
         self.srp = SenderReceiverProfile(self.inbox, num_samples, self)
 
-def extract_email(from_header):
-    if not from_header:
-        return None
-    from_header = from_header.lower()
-    r = re.search("([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)", from_header)
-    return r.group() if r else from_header
+# def extract_email(from_header):
+#     if not from_header:
+#         return None
+#     from_header = from_header.lower()
+#     r = re.search("([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)", from_header)
+#     return r.group() if r else from_header
 
 def removeSpaces(s):
     exp = " +$"


### PR DESCRIPTION
This feature allows you to choose between extracting the name or the email from the from header for all of the detectors. You can choose the name by setting `use_name_in_from` to anything but 0, and choose the email by setting `use_name_in_from` to 0.
