### PR TITLE
Script to test various solvers for debugging issues with training logistic regression.

### DIFF
--- a/common/analyzeMatrix.py
+++ b/common/analyzeMatrix.py
@@ -1,12 +1,12 @@
 import numpy as np
 
 """
-Analyzes a file called dataMatrix.npz located in the same directory as the file. The first row of the data matrix is assumed to be the feature name. The output is stored in a file called matrixStatistics.txt.
+Analyzes a file called training_data.npz located in the same directory as the file. The first row of the data matrix is assumed to be the feature name. The output is stored in a file called matrixStatistics.txt.
 """
 
-dataMatrix = np.load("dataMatrix.npz")
+dataMatrix = np.load("training_data.npz")
 outputStats = open("matrixStatistics.txt", "w")
-data = dataMatrix["arr_0"]
+data = dataMatrix["X"]
 numFeatures = data.shape[1]
 numSamples = data.shape[0]
 for i in range(numFeatures):

--- a/common/debug_training.py
+++ b/common/debug_training.py
@@ -1,0 +1,27 @@
+import logging
+import os
+import shlex
+import subprocess
+import time
+
+solvers = ["liblinear", "newton-cg", "lbfgs", "sag"]
+tolerances = [1e-4, 0.1]
+debug_logger = logging.getLogger('spear_phishing.debug')
+
+def run():
+    for solver in solvers:
+        for tolerance in tolerances:            
+            command = "python debug_training_scripts.py --solver {} --tol {}".format(solver, tolerance)
+            args = shlex.split(command)
+            process = subprocess.Popen(args)
+            start_time = time.time()
+            process.poll()
+            while process.returncode == None:
+                curr_time = time.time()
+                if curr_time - start_time > 60 * 10:
+                    debug_logger.warn("Terminating process for script: {} after {} seconds".format(command, int(curr_time - start_time)))
+                    process.terminate()
+                    time.sleep(1) # Sleep for 1 second so return code can be set.
+                process.poll()
+
+run()

--- a/common/debug_training_scripts.py
+++ b/common/debug_training_scripts.py
@@ -1,0 +1,32 @@
+import argparse
+import sys
+import time
+
+import numpy as np
+from sklearn import linear_model
+
+fp = open('../output/debug.log', 'a')
+
+parser = argparse.ArgumentParser(description='Debug the training step of the classifier.')
+parser.add_argument('--solver', dest="solver", type=str, default="liblinear")
+parser.add_argument('--tol', dest="tol", type=float, default=1e-4)
+
+args = parser.parse_args()
+
+training_data = np.load("training_data.npz")
+train_X = training_data["X"][1:,:] # We don't need feature names
+train_Y = training_data["Y"]
+
+class_weights = {1.0: 0.5, 0.0: 1.0}
+
+start_time = time.time()
+clf = linear_model.LogisticRegression(class_weight=class_weights,
+                                      solver=args.solver,
+                                      tol=args.tol,
+                                      verbose=1)
+clf.fit(train_X, train_Y.ravel())
+end_time = time.time()
+msg = "Using solver: {} and tolerance: {}, the test took {} seconds.".format(args.solver, args.tol, int(end_time - start_time))
+fp.write(msg + "\n")
+print(msg)
+fp.close()

--- a/common/phish_detector.py
+++ b/common/phish_detector.py
@@ -72,10 +72,14 @@ class PhishDetector(object):
         parser.add_argument('--classify',
                             action='store_true',
                             help=('Run ML model on test matrix'))
+        parser.add_argument('--debug_training',
+                            action='store_true',
+                            help=('Debug the training step of the pipeline.'))
         
         args = parser.parse_args()
 
         run = False
+        self.debug_training = False
         if args.all:
             self.generate_data_matrix = True
             self.generate_test_matrix = True
@@ -99,6 +103,14 @@ class PhishDetector(object):
         if args.classify:
             self.classify = True
             run = True
+        if args.debug_training:
+            self.generate_data_matrix = True
+            self.generate_test_matrix = True
+            self.generate_model = True
+            self.classify = True
+            self.debug_training = True
+            run = True
+
 
         if not run:
             parser.error('You must run with at least one flag')
@@ -232,7 +244,14 @@ class PhishDetector(object):
             progress_logger.info('Finished feature generation in {} minutes, {} seconds.'.format(min_elapsed, sec_elapsed))
 
     def generate_model_output(self):
-        self.classifier = Classify(self.weights, self.root_dir, self.emails_threshold, self.results_size, results_dir=self.result_path_out, serial_path=self.model_path_out, memlog_freq=self.memlog_classify_frequency)
+        self.classifier = Classify(self.weights,
+                                   self.root_dir,
+                                   self.emails_threshold,
+                                   self.results_size,
+                                   results_dir=self.result_path_out,
+                                   serial_path=self.model_path_out,
+                                   memlog_freq=self.memlog_classify_frequency,
+                                   debug_training=self.debug_training)
         self.classifier.generate_training()
         self.classifier.train_clf()
         self.classifier.cross_validate()

--- a/spear_phishing_detector.py
+++ b/spear_phishing_detector.py
@@ -4,7 +4,9 @@ import os
 
 from common import phish_detector
 
-# Usage: python spear_phishing_detector.py --all
+# Usage:
+# Normal operation: python spear_phishing_detector.py --all
+# Debug mode: python spear_phishing_detector.py --debug_training
 
 OUTPUT_DIRECTORY = "output"
 


### PR DESCRIPTION
### What is this?
Right now, we don't know why training the logistic regression classifer doesn't terminate on Vern's dataset. I added a mode to the pipeline that allows us to run a separate script that tries each of the 4 solvers with different tolerances, allowing each combination to run for 10 minutes max before terminating. The hope is that at least one of these combinations will terminate within the 10 minute limit, and we can proceed with using that combination in the actual pipeline.

To run the debug mode, we can use the following command: 
`python spear_phishing_detector.py --debug_training`

### How do we know this works?
Tested on some sample data to verify that the subprocesses terminate if they've been running for more than the fixed time interval. Verified that all of the information is being logged to the same location: `output/debug.log`. Ran the pipeline end to end with no issues.

to: @nexusapoorvacus @mikeaboody 
Would be great if one of you could try pulling this branch and running the debug mode to make sure it works for you as well and you see the logs in the file I specified above. Also, if you have any other combinations of settings on the classifier that you think would be useful to test in the script (i.e. potentially limiting max iterations?), please let me know and I can add those in.

cc: @davidwagner 