### PR TITLE
More memory profiling

### DIFF
--- a/common/config.yaml
+++ b/common/config.yaml
@@ -40,4 +40,4 @@ regular_filename:               legit_emails.log
 phish_filename:                 phish_emails.log
 
 #Progress Configurations
-logging_interval:               60
+logging_interval:               10

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -32,7 +32,7 @@ parallel:                       0
 num_threads:                    5
 
 #Memory Logging Settings
-memlog_gen_features_frequency:  60
+memlog_gen_features_frequency:  10
 memlog_classify_frequency:      1
 
 #Do not modify unless you are certain what you are doing

--- a/common/feature_classes.py
+++ b/common/feature_classes.py
@@ -14,7 +14,7 @@ from order_of_headers import OrderOfHeaderDetector
 from timezone import DateTimezoneDetector
 from received_headers import ReceivedHeadersDetector
 
-debug_logger = logging.getLogger('spear_phishing.debug')
+import logs
 
 class MessageIdDetectorOne(Detector):
     DELIMITERS = ['.', '-', '$', '/', '%']
@@ -61,11 +61,11 @@ class MessageIdDetectorOne(Detector):
             sender = self.extract_from(msg)
             message_id = msg["Message-ID"]
             if message_id == None:
-                debug_logger.warn("No message ID found, during create_sender_profile().")
+                logs.RateLimitedLog.log("No message ID found, during create_sender_profile().")
                 continue
             split_msg_id = message_id.split('@')
             if len(split_msg_id) < 2:
-                print("Message-ID misformatted: {}".format(message_id))
+                logs.RateLimitedLog.log("Message-ID misformatted", private=message_id)
                 continue
             domain = split_msg_id[1][:-1]
             uid = split_msg_id[0][1:]
@@ -86,11 +86,11 @@ class MessageIdDetectorOne(Detector):
         sender = self.extract_from(phish)
         message_id = phish["Message-ID"]
         if message_id == None:
-            debug_logger.warn("No message ID found, during classify().")
+            logs.RateLimitedLog.log("No message ID found, during classify().")
             return [0.0, 0.0]
         split_msg_id = message_id.split('@')
         if len(split_msg_id) < 2:
-            debug_logger.warn("Message-ID misformatted: {}".format(message_id))
+            logs.RateLimitedLog.log("Message-ID misformatted", private=message_id)
             return [0.0, 0.0]
         domain = split_msg_id[1][:-1]
         uid = split_msg_id[0][1:]

--- a/common/generate_features.py
+++ b/common/generate_features.py
@@ -91,6 +91,7 @@ class FeatureGenerator(object):
         for i, detector in enumerate(detectors):
             logs.context['detector'] = type(detector).__name__
             detector.create_sender_profile(self.sender_profile_num_emails)
+            logs.Watchdog.reset()
             logs.RateLimitedMemTracker.checkmem('finished creating sender profile')
         del logs.context['step']
         del logs.context['detector']
@@ -113,6 +114,7 @@ class FeatureGenerator(object):
                     data_matrix[row_index][j] = float(heuristic) if heuristic else 0.0
                     j += 1
             row_index += 1
+        logs.Watchdog.reset()
         for i in range(self.start_data_matrix_index, self.start_test_matrix_index):
             j = 0
             for detector in self.detectors:
@@ -125,6 +127,7 @@ class FeatureGenerator(object):
                     data_matrix[row_index][j] = float(heuristic) if heuristic else 0.0
                     j += 1
             row_index += 1
+        logs.Watchdog.reset()
         del logs.context['step']
         return data_matrix
     
@@ -149,6 +152,7 @@ class FeatureGenerator(object):
                     j += 1
             row_index += 1
         test_email_index = np.arange(self.start_test_matrix_index, self.num_emails)
+        logs.Watchdog.reset()
         del logs.context['step']
         return test_data_matrix, test_email_index, test_mess_id
     

--- a/common/generate_features.py
+++ b/common/generate_features.py
@@ -85,12 +85,18 @@ class FeatureGenerator(object):
 
 
     def build_detectors(self, inbox):
+        logs.context['step'] = 'build_detectors'
         detectors = [Detector(inbox) for Detector in self.features]
         for i, detector in enumerate(detectors):
+            logs.context['detector'] = type(detector).__name__
             detector.create_sender_profile(self.sender_profile_num_emails)
+            logs.RateLimitedMemTracker.checkmem('finished creating sender profile')
+        del logs.context['step']
+        del logs.context['detector']
         return detectors
     
     def generate_data_matrix(self, inbox, phish_inbox):
+        logs.context['step'] = 'generate_data_matrix'
         data_matrix = np.empty(shape=(self.data_matrix_num_emails*2, self.num_features))
     
         row_index = 0
@@ -118,9 +124,11 @@ class FeatureGenerator(object):
                     data_matrix[row_index][j] = float(heuristic) if heuristic else 0.0
                     j += 1
             row_index += 1
+        del logs.context['step']
         return data_matrix
     
     def generate_test_matrix(self, test_mbox):
+        logs.context['step'] = 'generate_test_matrix'
         test_data_matrix = np.empty(shape=(self.num_emails - self.start_test_matrix_index, self.num_features))
     
         test_mess_id = np.empty(shape=(self.num_emails - self.start_test_matrix_index, 1), dtype='S200')
@@ -140,6 +148,7 @@ class FeatureGenerator(object):
                     j += 1
             row_index += 1
         test_email_index = np.arange(self.start_test_matrix_index, self.num_emails)
+        del logs.context['step']
         return test_data_matrix, test_email_index, test_mess_id
     
     def generate_labels(self):

--- a/common/generate_features.py
+++ b/common/generate_features.py
@@ -29,6 +29,7 @@ import numpy as np
 import scipy.io as sio
 
 import feature_classes as fc
+import logs
 
 progress_logger = logging.getLogger('spear_phishing.progress')
 

--- a/common/inbox.py
+++ b/common/inbox.py
@@ -5,8 +5,7 @@ import copy
 import time
 import email.utils
 import logging
-
-debug_logger = logging.getLogger('spear_phishing.debug')
+import logs
 
 class Inbox():
 	def __init__(self, root=None):
@@ -24,7 +23,7 @@ class Inbox():
 						header_tuples = eval(line)
 						self.emails.append(Email(header_tuples))	
 					except:
-						debug_logger.warn("Invalid Email, during processEmails()")
+                                                logs.RateLimitedLog("Invalid Email, during processEmails()", private=line)
 						self.num_invalid_emails += 1
 		elif os.path.isdir(root):
 			for item in os.listdir(root):

--- a/common/logs.py
+++ b/common/logs.py
@@ -1,0 +1,94 @@
+import logging
+import psutil
+from memtest import MemTracker
+import signal
+import traceback
+import threading
+import sys
+
+progress_logger = logging.getLogger('spear_phishing.progress')
+debug_logger = logging.getLogger('spear_phishing.debug')
+memory_logger = logging.getLogger('spear_phishing.memory')
+
+class RateLimitedMemTracker(object):
+    all_tasks = {}
+
+    def __init__(self, task=""):
+        self.max_mem_logged = 100000000 # don't log until RSS reaches 100MB
+        self.task = task
+
+    def checkmem_rate_limited(self):
+        cur = MemTracker.cur_mem_usage()
+        if cur >= 2*self.max_mem_logged:
+            self.max_mem_logged = cur
+            MemTracker.logMemory(self.task)
+
+    @classmethod
+    def checkmem(cls, task):
+        if not task in cls.all_tasks:
+            cls.all_tasks[task] = RateLimitedMemTracker(task)
+        cls.all_tasks[task].checkmem_rate_limited()
+
+class RateLimitedLog(object):
+    all_tasks = {}
+
+    def __init__(self, task=""):
+        self.times_called = 0
+        self.last_logged  = 0
+        self.task = task
+
+    def log_rate_limited(self, private, public):
+        self.times_called += 1
+        if self.times_called < 2*self.last_logged:
+            return
+        progress_logger.info("{} (#{}) {}".format(self.task, self.times_called, public))
+        if private != "":
+            debug_logger.info("{} (#{}) {}; {}".format(self.task, self.times_called, public, private))
+        self.last_logged = self.times_called
+
+    @classmethod
+    def log(cls, task, private="", public=""):
+        if not task in cls.all_tasks:
+            cls.all_tasks[task] = RateLimitedLog(task)
+        cls.all_tasks[task].log_rate_limited(private, public)
+
+    @classmethod
+    def flushall():
+        progress_logger.info('Summary of multiply-repeated log messages:')
+        s = sorted(all_tasks.values(), key=lambda l: l.times_called, reverse=True)
+        for l in s:
+            if l.times_called > 1:
+                progress_logger("{: >5} instances of {}".format(l.times_called, l.task))
+
+
+
+
+class Watchdog(object):
+    duration = 5  # Initially, 10 minutes
+
+    @classmethod
+    def initialize(cls):
+        signal.signal(signal.SIGALRM, cls.timer_expired)
+        progress_logger.info('Started watchdog timer; {} seconds'.format(Watchdog.duration))
+        cls.reset()
+
+    @classmethod
+    def reset(cls):
+        signal.alarm(cls.duration)
+
+    @staticmethod
+    def log_all_stack_frames():
+        # http://stackoverflow.com/a/2569696/781723
+        id2name = dict([(th.ident, th.name) for th in threading.enumerate()])
+        for threadId, stack in sys._current_frames().items():
+            memory_logger.info(" # Thread: %s(%d)\n" % (id2name.get(threadId,""), threadId) + ''.join(traceback.format_stack(stack)))
+
+    @staticmethod
+    def timer_expired(sig, frame):
+        progress_logger.info('Watchdog expired (more than {} seconds passed)'.format(Watchdog.duration))
+        memory_logger.info('Watchdog expired, dumping all stack frames:'.format(Watchdog.duration))
+        Watchdog.log_all_stack_frames()
+        MemTracker.logMemory('watchdog expired')
+        Watchdog.duration *= 2
+        progress_logger.info('Setting new watchdog timer, for {} seconds'.format(Watchdog.duration))
+        Watchdog.reset()

--- a/common/logs.py
+++ b/common/logs.py
@@ -67,7 +67,7 @@ class RateLimitedLog(object):
 
 
 class Watchdog(object):
-    duration = 5  # Initially, 10 minutes
+    duration = 600  # Initially, 10 minutes
 
     @classmethod
     def initialize(cls):

--- a/common/logs.py
+++ b/common/logs.py
@@ -56,9 +56,9 @@ class RateLimitedLog(object):
         cls.all_tasks[task].log_rate_limited(private, public)
 
     @classmethod
-    def flushall():
+    def flushall(cls):
         progress_logger.info('Summary of multiply-repeated log messages:')
-        s = sorted(all_tasks.values(), key=lambda l: l.times_called, reverse=True)
+        s = sorted(cls.all_tasks.values(), key=lambda l: l.times_called, reverse=True)
         for l in s:
             if l.times_called > 1:
                 progress_logger("{: >5} instances of {}".format(l.times_called, l.task))

--- a/common/memtest.py
+++ b/common/memtest.py
@@ -2,6 +2,7 @@ import os
 from guppy import hpy
 import datetime as dt
 import logging
+import psutil
 
 class MemTracker(object):
     logger = None
@@ -17,14 +18,20 @@ class MemTracker(object):
         MemTracker.heapy_instance.setrelheap()
 
 
+    @staticmethod
+    def cur_mem_usage():
+        return psutil.Process().memory_info().rss
+
     @classmethod
     def logMemory(cls, section_name):
         if MemTracker.logger == None:
             raise RuntimeError("Initialize before calling.")
         MemTracker.logger.info("Memory statistics for '" + section_name + "':")
+        MemTracker.logger.info("Current total RSS: " + str(MemTracker.cur_mem_usage()))
         start = dt.datetime.now()
         h = MemTracker.heapy_instance.heap()
         MemTracker.logger.info(str(h))
         end = dt.datetime.now()
         delta = end - start
         MemTracker.logger.info("Profiling took " + str(delta.seconds) + " seconds.")
+

--- a/common/memtest.py
+++ b/common/memtest.py
@@ -22,7 +22,7 @@ class MemTracker(object):
 
     @staticmethod
     def cur_mem_usage():
-        return proc.memory_info().rss
+        return MemTracker.proc.memory_info().rss
 
     @classmethod
     def logMemory(cls, section_name):

--- a/common/memtest.py
+++ b/common/memtest.py
@@ -7,6 +7,7 @@ import psutil
 class MemTracker(object):
     logger = None
     heapy_instance = None
+    proc = None
 
     @classmethod
     def initialize(cls, logger):
@@ -16,11 +17,12 @@ class MemTracker(object):
         MemTracker.logger.info("Logger set. Relative heap set. Ready for memory tracking")
         MemTracker.heapy_instance = hpy()
         MemTracker.heapy_instance.setrelheap()
+        MemTracker.proc = psutil.Process()
 
 
     @staticmethod
     def cur_mem_usage():
-        return psutil.Process().memory_info().rss
+        return proc.memory_info().rss
 
     @classmethod
     def logMemory(cls, section_name):

--- a/common/phish_detector.py
+++ b/common/phish_detector.py
@@ -14,6 +14,7 @@ import feature_classes as fc
 from generate_features import FeatureGenerator
 from lookup import Lookup
 from memtest import MemTracker
+import logs
 
 progress_logger = logging.getLogger('spear_phishing.progress')
 debug_logger = logging.getLogger('spear_phishing.debug')
@@ -234,6 +235,7 @@ class PhishDetector(object):
             end_of_last_memory_track = dt.datetime.now()
             for directory in dir_to_generate:
                 dir_count += 1
+                logs.context = {'feature gen': dir_count}
                 curr_time = time.time()
                 if (curr_time - last_logged_time) > self.logging_interval * 60:
                     progress_logger.info('Processing directory #{} of {}'.format(dir_count, len(dir_to_generate)))
@@ -247,6 +249,7 @@ class PhishDetector(object):
                     end_of_last_memory_track = dt.datetime.now()
                 feature_generator = self.prep_features(directory)
                 feature_generator.run()
+                logs.context = {}
             end_time = time.time()
             min_elapsed, sec_elapsed = int((end_time - start_time) / 60), int((end_time - start_time) % 60)
             progress_logger.info('Finished feature generation in {} minutes, {} seconds.'.format(min_elapsed, sec_elapsed))

--- a/common/phish_detector.py
+++ b/common/phish_detector.py
@@ -272,15 +272,20 @@ class PhishDetector(object):
     def execute(self):
         start_time = time.time()
         MemTracker.initialize(memory_logger)
+        logs.context = {'phase': 'generate_features'}
         if self.generate_data_matrix or self.generate_test_matrix:
             self.generate_features()
+        logs.context = {}
         MemTracker.logMemory("After generating features/Before generating model")
+        logs.context = {'phase': 'generate_model_output'}
         if self.generate_model:
             self.generate_model_output()
+        logs.context = {}
         MemTracker.logMemory("After generating model")
         end_time = time.time()
         min_elapsed, sec_elapsed = int((end_time - start_time) / 60), int((end_time - start_time) % 60)
         progress_logger.info("Phish Detector took {} minutes, {} seconds to run.".format(min_elapsed, sec_elapsed))
+        logs.RateLimitedLog.flushall()
 
 def run_generator(generator):
     #Load offline info for Lookup class

--- a/common/phish_detector.py
+++ b/common/phish_detector.py
@@ -17,7 +17,6 @@ from memtest import MemTracker
 import logs
 
 progress_logger = logging.getLogger('spear_phishing.progress')
-debug_logger = logging.getLogger('spear_phishing.debug')
 memory_logger = logging.getLogger('spear_phishing.memory')
 
 class PhishDetector(object):
@@ -127,7 +126,7 @@ class PhishDetector(object):
         try:
             stream = file(self.config_path, 'r')
         except IOError:
-            debug_logger.exception("Could not find yaml configuration file.")
+            progress_logger.exception("Could not find yaml configuration file.")
             raise
 
         config = yaml.load(stream)
@@ -159,7 +158,7 @@ class PhishDetector(object):
             for key in expected_config_keys:
                 setattr(self, key, config[key])
         except KeyError:
-            debug_logger.exception("Configuration file missing entry")
+            progress_logger.exception("Configuration file missing entry")
             raise
 
         detectors = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scipy
 scikit-learn==0.17
 whois==0.7
 guppy>=0.1.10
+psutil


### PR DESCRIPTION
This does a whole bunch more profiling, to try to understand why the detector is slow.  It includes a watchdog, which triggers a memory profile operation if any step has taken more than 10 minutes, and additional logging at various points.  It also adds some support for additional logging, including rate-limited logging.  Finally, config parameters are changed to trigger more-frequent logging.

Hopefully no functionality should be changed.

Please review.