### PR TITLE
ReceivedHeaderDetector improvements

### DIFF
--- a/common/received_headers.py
+++ b/common/received_headers.py
@@ -20,7 +20,7 @@ def lookup_cidr_from_hop(hop):
    through and look up the containing CIDR netblock."""
 def extract_cidr_from_rcvd_hdr(content):
     content = content.translate(None, '\n\r\t')
-    for end_token in ["by", "via", "with", "id", "for", ";", "$"]
+    for end_token in ["by", "via", "with", "id", "for", ";", "$"]:
         r = re.search('from +(.*) +' + end_token, content)
         if r:
             return lookup_cidr_from_hop(r.group(1).strip())
@@ -75,7 +75,7 @@ class ReceivedHeadersDetector(Detector):
     def create_sender_profile(self, num_samples):
         for i in range(num_samples):
             msg = self.inbox[i]
-            sender = self.extract_from(phish)
+            sender = self.extract_from(msg)
             mailpath = extract_mailpath_from_email(msg)
             if sender:
                 self.sender_profile[sender].add_mailpath(mailpath)


### PR DESCRIPTION
 Major refactoring of ReceivedHeaderDetector, with many changes:

* Saves memory by only storing one entry per mailpath seen, fixes #79
* Uses EDBag to speed up finding the edit distance to the most  similar mailpath in the sender profile, fixes #78
* More efficient parsing of received headers to pull out only the  part we actually use in this detector, fixes #77
* Other minor improvements: use built-in string operations rather  than regexps for performance, use iterators for cleaner code