### PR TITLE
Fixed shuffling in parse_pcap phase.

### DIFF
--- a/broScripts/parse_pcap.py
+++ b/broScripts/parse_pcap.py
@@ -185,7 +185,9 @@ try:
     progress_logger.info('Done. Created {} directories in {} minutes, {} seconds.'.format(dir_num, min_elapsed, sec_elapsed))
     senders_seen.close()
 
-    os.system('shuf {} > /dev/null'.format(SENDERS_FILE))
+    shuffle_command = "shuf {} --output={}".format(SENDERS_FILE, SENDERS_FILE)
+    progress_logger.info("Executing: {}".format(shuffle_command))
+    os.system(shuffle_command)
 
     # Generating phish emails
     senders_seen = open(SENDERS_FILE)

--- a/broScripts/parse_pcap_mbox.py
+++ b/broScripts/parse_pcap_mbox.py
@@ -160,7 +160,9 @@ try:
     progress_logger.info('Done.  Created #{} directories.'.format(dir_num))
     senders_seen.close()
 
-    os.system('shuf {} > /dev/null'.format(SENDERS_FILE))
+    shuffle_command = "shuf {} --output={}".format(SENDERS_FILE, SENDERS_FILE)
+    progress_logger.info("Executing: {}".format(shuffle_command))
+    os.system(shuffle_command)
 
     # Generating phish emails
     senders_seen = open(SENDERS_FILE)


### PR DESCRIPTION
### What is this?

Fix for https://github.com/mikeaboody/phishing-research/issues/95. 

### How do we know this works?

Tested on my own inbox using the `--mbox` flag, and the validation accuracy improved from 50% to 87.5% and there were actually emails classified as positive. Also sampled several directories in the output of the pcap parsing phase and verified that `legit_emails.log` was not identical to `phish_emails.log`.