### PR TITLE
Fixed Order of Headers sender profile initialization

### DIFF
--- a/common/order_of_headers.py
+++ b/common/order_of_headers.py
@@ -10,8 +10,9 @@ class Profile(object):
     """For each email, we extract the order in which the headers appeared;
        this keeps track of all of the header-orders seen in any email from
        a particular sender."""
-    num_emails = 0
-    orderings = EDBag()
+    def __init__(self):
+        self.num_emails = 0
+        self.orderings = EDBag()
 
     def add_order(self, order):
         self.orderings.add(order)
@@ -100,13 +101,6 @@ class OrderOfHeaderDetector(Detector):
         if nords > 256:
             debug_logger = logging.getLogger('spear_phishing.debug')
             debug_logger.info('Large number of orderings ({}) for sender, emails_with_sender={}; {}'.format(nords, self.emails_with_sender, logs.context))
-
-            # more debugging for Matt.
-            # TODO: delete this after we've tracked down what is going on
-            # with bug #94
-            for sender, prof in self.sender_profile.items():
-                debug_logger.info('  Sender {} has {} orderings across {} emails'.format(sender, len(prof.orderings), prof.num_emails))
-
 
     def trim_distributions(self, distr):
         while distr[len(distr)-1] == 0:


### PR DESCRIPTION
### What is this?
This should fix https://github.com/mikeaboody/phishing-research/issues/94. The issue here was that inside of the `Profile` class, `orderings` is defined as a class variable, not an instance variable. Therefore, whenever we updated `orderings` using the line `self.orderings.add(order)`, we are modifying the same `EDBag` (in Python, if you reference `self.orderings` and there is no instance variable `orderings`, it will automatically check to see if there is a class variable `orderings`.

### How do we know this works?
After fixing this, I no longer see any complaints of large numbers of orderings. Also, the cross-validation accuracy on my mbox improved from 87.5% to 89.2%.

I checked `received_headers.py` to see if that detector had the same issue, but it looks like that one is fine.

cc: @davidwagner 