### PR TITLE
in sklearn, use model_selection instead of cross_validation.

### DIFF
--- a/common/classify.py
+++ b/common/classify.py
@@ -10,7 +10,7 @@ import time
 
 import numpy as np
 import scipy.io as sio
-from sklearn import linear_model, cross_validation
+from sklearn import linear_model, model_selection
 from sklearn.utils import shuffle
 from sklearn.externals import joblib
 
@@ -95,7 +95,7 @@ class Classify:
     def cross_validate(self):
         progress_logger.info("Starting cross validation.")
         validate_clf = linear_model.LogisticRegression(class_weight=self.weights)
-        predictions = cross_validation.cross_val_predict(validate_clf, self.X, self.Y.ravel(), cv=5)
+        predictions = model_selection.cross_val_predict(validate_clf, self.X, self.Y.ravel(), cv=5)
         fp_count = 0.0
         tp_count = 0.0
         fn_count = 0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ netaddr==0.7.18
 numpy
 PyYAML==3.11
 scipy
-scikit-learn==0.17
+scikit-learn==0.18
 whois==0.7
 guppy>=0.1.10
 psutil


### PR DESCRIPTION
Fix for https://github.com/mikeaboody/phishing-research/issues/104. Note that this means we'll need to use at least version 0.18 of sci-kit learn, so we'll need to let Vern know to run 

`pip install -r requirements.txt` (or potentially `pip2 install -r requirements.txt`) again.

cc: @davidwagner @nexusapoorvacus @mikeaboody 
