### PR TITLE
Remove caching from EDBag, as it will probably be ineffective

### DIFF
--- a/common/edbag.py
+++ b/common/edbag.py
@@ -1,6 +1,5 @@
 from collections import Counter
 import editdistance
-from repoze.lru import LRUCache
 
 """A bag (multiset) of tuples, supporting edit distance operations over 
    its elements and a count of the number of times each element occurs.
@@ -9,12 +8,8 @@ from repoze.lru import LRUCache
 class EDBag(Counter):
     def __init__(self):
         super(EDBag, self).__init__()
-        self.cache1 = LRUCache(256) # values where distance=1
-        self.cache2 = LRUCache(256) # values where distance>1
 
     def add(self, x):
-        if not x in self:
-            self.cache2.clear()
         self[x] += 1
 
     def closest_by_edit_distance(self, x):
@@ -22,15 +17,6 @@ class EDBag(Counter):
             # Optimization: if x is in multiset, then closest
             # edit dist = 0. Nothing can be any closer.
             return (x, 0)
-
-        # Optimization: If we've looked up this value before, 
-        # return previously computed answer.
-        cached_answer = self.cache1.get(x)
-        if cached_answer:
-            return cached_answer
-        cached_answer = self.cache2.get(x)
-        if cached_answer:
-            return cached_answer
 
         closest = None
         closest_dist = None
@@ -43,8 +29,6 @@ class EDBag(Counter):
                     # Optimization: nothing can be any closer, as
                     # we know there's nothing at edit distance 0 (x is not
                     # in the multiset).
-                    self.cache1.put(x, (closest, closest_dist))
                     return (closest, closest_dist)
 
-        self.cache2.put(x, (closest, closest_dist))
         return (closest, closest_dist)


### PR DESCRIPTION
Remove caching from EDBag, as it will probably be ineffective now that we have sender profiles update on the fly.  Fixes #108.