### PR TITLE
Detector Ranking in Output

### DIFF
--- a/common/config.yaml
+++ b/common/config.yaml
@@ -13,7 +13,7 @@ weights:
     negative:                   1.0
 model_path_out:                 model.plk
 result_path_out:                output
-results_size:                   10
+results_size:                   20
 emails_threshold:               1000
 batch_threading_size:           100
 offline:                        1

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -5,7 +5,7 @@ root_dir:                       ../broScripts/output
 sender_profile_percentage:      0.1
 data_matrix_percentage:         0.2
 test_matrix_percentage:         0.7
-use_name_in_from:               1
+use_name_in_from:               0
 
 #Model Training and Classification Settings
 weights:

--- a/common/priorityQueue.py
+++ b/common/priorityQueue.py
@@ -1,12 +1,14 @@
 import bisect
 
 class PriorityQueue:
-    def __init__(self):
+    def __init__(self, maxQueueSize):
         # self._queue has a tuple with three values: (priority, self._id, and item)
         # The priority is the probability and the item is an email represented by a numpy array
         self._queue = []
         self._size = 0
         self._id = 0
+	self.MAX_SIZE = maxQueueSize 
+	
 
         # a unique sender is determined by the path to the sender's emails
         self._uniqueSenders = set([])
@@ -40,7 +42,7 @@ class PriorityQueue:
         self._size += 1
 
         # maintains the queue to have 10 elements or less
-        if self._size > 10:
+        if self._size > self.MAX_SIZE:
             popped = self._queue.pop(0)
             self._uniqueSenders.remove(popped[2][0])
             self._size -= 1


### PR DESCRIPTION
This pull request makes a modification to the `get_detector_contribution` function in classify.py. Previously when the detector contributions were ranked, the data values were not being subtracted by the mean value of the column before being multiplied by the feature coefficient.

Previous: data value * alpha (coefficient for column)
Current: (data value - mean(column)) * alpha (coefficient for column)

This pull request also creates two results.txt files, one in /common/output/high_volume and another in /common/output/low_volume. Each text file contains the From, Subject, Top 3 detectors contributed, and the name of the json file of each email contained in /common/output/high_volume, and likewise for /common/output/low_volume. An example of how this file might look is below:

results.txt
Results:
0.json:
        From: name (email)
        Subject: subject
        Top 3 Detectors(in order): detector name 1, detector name 2, detector name 3

1.json:
        From: name (email)
        Subject: subject
        Top 3 Detectors(in order): detector name 1, detector name 2, detector name 3
...

@mikeaboody Can you review the PR? If it looks good, then lets merge and ask Vern to run our detector again.