### PR TITLE
Classify refactor

### DIFF
--- a/broScripts/mboxToFile.py
+++ b/broScripts/mboxToFile.py
@@ -11,9 +11,7 @@ def createFile(inbox, num_emails):
             value = value.replace("\r", "")
             value = value.replace("\n", "")
             value = value.replace("'", "\\'")
-            header = header.replace("'", "\\'")
-            if header == "From":
-                header = "FROM"
+            header = header.replace("'", "\\'").upper()
             if len(line) == 1:
                 line += "('"+ header + "','" + value +"')"
             else:

--- a/common/classify.py
+++ b/common/classify.py
@@ -16,6 +16,7 @@ from sklearn.externals import joblib
 
 from memtest import MemTracker
 from priorityQueue import PriorityQueue
+from resultRecord import ResultRecord
 
 PATH_IND = 0
 LEGIT_IND = 1
@@ -180,7 +181,9 @@ class Classify:
         num_message_id_failed = 0
         total_completed = 0
 
-        for root, dirs, files in os.walk(self.email_path):
+	self.d_name_per_feat = self.parse_feature_names()
+        
+	for root, dirs, files in os.walk(self.email_path):
             curr_time = time.time()
             if (curr_time - last_logged_time) > logging_interval * 60:
                 progress_logger.info('Exploring directory #{}'.format(num_senders_completed))
@@ -211,14 +214,15 @@ class Classify:
                     #progress_logger.exception(e)
                     num_message_id_failed += 1
                     test_mess_id = np.zeros(shape=(sample_size, 1), dtype="S200")
-                test_res = self.output_phish_probabilities(test_X, indx, root, test_indx, test_mess_id)
-                if test_res is not None:
+                #test_res = self.output_phish_probabilities(test_X, indx, root, test_indx, test_mess_id)
+		test_res = self.get_email_records(test_X, indx, root, test_indx, test_mess_id)
+		if test_res is not None:
                     for email in test_res:
                         testSize += 1
-                        sender = self.get_sender(email[0])
-                        emailPath = email[0]
-                        probability = float(email[2])
-                        message_ID = email[4].strip(" ")
+                        sender = self.get_sender(email.path)
+                        emailPath = email.path
+                        probability = float(email.probability_phish)
+                        message_ID = email.message_id.strip(" ")
                         if probability > 0.5:
                             numPhish += 1
 
@@ -244,14 +248,12 @@ class Classify:
 
         email_probabilities.close()
         self.num_phish, self.test_size = numPhish, testSize
-        low_volume_output = low_volume_top_10.createOutput()
+	low_volume_output = low_volume_top_10.createOutput()
         high_volume_output = high_volume_top_10.createOutput()
         output = [low_volume_output, high_volume_output]
 
         # DEBUG information - don't print to main log
         # debug_logger.info(pp.pformat(output))
-
-        self.d_name_per_feat = self.parse_feature_names()
         self.pretty_print(low_volume_output, "low_volume")
         self.pretty_print(high_volume_output, "high_volume")
         self.write_summary_output(output)
@@ -270,33 +272,28 @@ class Classify:
 	results =  open(full_path, "w")
 	results.write("Results:\n")
 	
-        for i, row in enumerate(output):
-            path = row[PATH_IND]
-            indx = int(row[LEGIT_IND])
-            test_indx = int(row[TEST_IND])
-            break_down = self.get_detector_contribution(path, test_indx)
-	    break_down_list = break_down.items()
-            headers = eval(self.get_email(path, indx))
-            headers_dict = self.to_dictionary(headers)
+        for i, record in enumerate(output):
+            path = record.path
+            indx = record.email_index
+            test_indx = record.test_index
+            headers_dict = record.all_headers
 	    
             results.write(str(i) + ".json:\n")
-            results.write("\tFrom: " + headers_dict["FROM"] + "\n")
-            subject = ""
-            if 'Subject' in headers_dict:
-		subject = headers_dict["Subject"]
-	    results.write("\tSubject: " + subject + "\n")
-	    results.write("\tTop 3 Detectors(in order): " + str(break_down_list[0][0]) + ", " + str(break_down_list[1][0]) + ", " + str(break_down_list[2][0]) + "\n\n")
+            results.write("\tFrom: " + record.email_from + "\n")
+	    results.write("\tSubject: " + record.email_subject + "\n")
+	    results.write("\tTop 3 Detectors(in order): " + str(record.detector_contribution[0]) + ", " + str(record.detector_contribution[1]) + ", " + str(record.detector_contribution[2]) + "\n\n")
             
-            self.write_file(folder_name, i, headers_dict, row[PROBA_IND], break_down)
+            self.write_file(folder_name, i, headers_dict, record.probability_phish, record.detector_contribution)
 	results.close()
 
-    def get_detector_contribution(self, path, test_indx):
+    def get_detector_contribution(self, test_X, test_indx):
         # Removing the ending "legit_emails.log" and adding "test.mat"
-        path = path[:-16] + "test.mat"
-        data = sio.loadmat(path)
-        test_sample = data['test_data'][test_indx]
+        # don't need to load test matrix again
+	#path = path[:-16] + "test.mat"
+        #data = sio.loadmat(path)
+        test_sample = test_X[test_indx]
         # get column averages
-        col_averages = np.mean(data['test_data'], axis=0).reshape((self.num_features,1))
+        col_averages = np.mean(test_X, axis=0).reshape((self.num_features,1))
         test_sample_minus_mean = test_sample.reshape((self.num_features, 1)) - col_averages
         product = np.multiply(test_sample_minus_mean.reshape(self.num_features), self.clf_coef)
         d_contribution = {}
@@ -347,7 +344,10 @@ class Classify:
             coefs = sorted(zip(map(lambda x: round(x, 4), self.clf_coef), self.feature_names), reverse=True)
             coefs = [x[1] + ": " + str(x[0]) for x in coefs]
             out.write(json.dumps(coefs, indent=2))
-            out.write(json.dumps(output, sort_keys=False, indent=4, separators=(",", ": ")))
+            out.write("Low Volume Senders: \n")
+            out.write(str(output[0]) + "\n\n")
+	    out.write("High Volume Senders: \n")
+	    out.write(str(output[1]) + "\n\n")
 
     def get_email(self, path, indx):
         with open(path) as fp:
@@ -358,6 +358,25 @@ class Classify:
     def get_sender(self, path):
         return path.split('/')[-2]
 
+
+    def get_email_records(self, test_X, indx, path, test_indx, test_mess_id):
+	sample_size = test_X.shape[0]
+        if sample_size == 0:
+            return []
+        
+        path = os.path.join(path, "legit_emails.log")
+        prob_phish = self.clf.predict_proba(test_X)[:,1].reshape(sample_size,1)
+        prob_phish[prob_phish < float(0.0001)] = 0
+        
+        records = []
+        for i in range(sample_size):
+            detector_contribution = self.get_detector_contribution(test_X, test_indx[i][0])
+	    header_breakdown = self.to_dictionary(eval(self.get_email(path, indx[i])))
+            records.append(ResultRecord(path, indx[i][0], prob_phish[i][0], test_indx[i][0], test_mess_id[i][0], detector_contribution, header_breakdown))
+        return records
+
+
+    # obselete because of get_email_records 
     def output_phish_probabilities(self, test_X, indx, path, test_indx, test_mess_id):
         # Outputs matrix with columns:
         # [path, index_in_legit_email, prob_phish, test_indx, message_id]

--- a/common/classify.py
+++ b/common/classify.py
@@ -214,12 +214,12 @@ class Classify:
                     #progress_logger.exception(e)
                     num_message_id_failed += 1
                     test_mess_id = np.zeros(shape=(sample_size, 1), dtype="S200")
-                #test_res = self.output_phish_probabilities(test_X, indx, root, test_indx, test_mess_id)
 		test_res = self.get_email_records(test_X, indx, root, test_indx, test_mess_id)
 		if test_res is not None:
                     for email in test_res:
                         testSize += 1
-                        sender = self.get_sender(email.path)
+                        #sender = self.get_sender(email.path)
+			sender = email.email_from
                         emailPath = email.path
                         probability = float(email.probability_phish)
                         message_ID = email.message_id.strip(" ")

--- a/common/classify.py
+++ b/common/classify.py
@@ -287,10 +287,6 @@ class Classify:
 	results.close()
 
     def get_detector_contribution(self, test_X, test_indx):
-        # Removing the ending "legit_emails.log" and adding "test.mat"
-        # don't need to load test matrix again
-	#path = path[:-16] + "test.mat"
-        #data = sio.loadmat(path)
         test_sample = test_X[test_indx]
         # get column averages
         col_averages = np.mean(test_X, axis=0).reshape((self.num_features,1))
@@ -373,29 +369,4 @@ class Classify:
             detector_contribution = self.get_detector_contribution(test_X, test_indx[i][0])
 	    header_breakdown = self.to_dictionary(eval(self.get_email(path, indx[i])))
             records.append(ResultRecord(path, indx[i][0], prob_phish[i][0], test_indx[i][0], test_mess_id[i][0], detector_contribution, header_breakdown))
-        return records
-
-
-    # obselete because of get_email_records 
-    def output_phish_probabilities(self, test_X, indx, path, test_indx, test_mess_id):
-        # Outputs matrix with columns:
-        # [path, index_in_legit_email, prob_phish, test_indx, message_id]
-        # test_indx necessary for relooking up the test_indxth sample of
-        # the test matrix when ranking feature contribution.
-        sample_size = test_X.shape[0]
-        if sample_size == 0:
-            return None
-        path_array = np.array([os.path.join(path, "legit_emails.log")])
-        path_array = np.repeat(path_array, sample_size, axis=0).reshape(sample_size, 1)
-        predictions = self.clf.predict(test_X).reshape(sample_size, 1)
-        prob_phish = self.clf.predict_proba(test_X)[:,1].reshape(sample_size, 1)
-        prob_phish[prob_phish < float(0.0001)] = 0
-        path_id = np.concatenate((path_array, indx), axis=1)
-        res = np.empty(shape=(sample_size, 0))
-        res = np.concatenate((res, path_id), 1)
-        res = np.concatenate((res, prob_phish), 1)
-        res = np.concatenate((res, test_indx), 1)
-        res = np.concatenate((res, test_mess_id), 1)
-        # Assumes prob_phish is 3rd column (index 2) and sorts by that.
-        res_sorted = res[res[:,PROBA_IND].argsort()][::-1]
-        return res_sorted
+        return records 

--- a/common/classify.py
+++ b/common/classify.py
@@ -9,6 +9,7 @@ from subprocess import call
 import sys
 import time
 import inbox
+import logs
 
 import numpy as np
 import scipy.io as sio
@@ -358,6 +359,16 @@ class Classify:
             detector_contribution = self.get_detector_contribution(test_X, test_indx[i][0], col_averages)
             email = senderInbox[indx[i][0]]
             # make sure that message ID in disk for this email is the same as the corresponding test_mess_id passed in
-            assert (email["MESSAGE-ID"] == test_mess_id[i][0].strip(" ") or (test_mess_id[i][0].strip(" ") == 'None' and type(email["MESSAGE-ID"]) == type(None)))
+            self.check_message_id(email["MESSAGE-ID"], test_mess_id[i][0])
             records.append(ResultRecord(path, indx[i][0], prob_phish[i][0], test_indx[i][0], detector_contribution, email))
         return records 
+
+    def check_message_id(self, email, test):
+        m2 = test.strip(" ")
+        if email is None and m2 == 'None':
+            return
+        m1 = email.strip(" ")
+        if m1 == m2:
+            return
+        logs.RateLimitedLog.log("Message IDs don't match.")
+        debug_logger.info("Message IDs don't match.\n  Email msg id: |{}|\n  Test msg id:  |{}|".format(m1, m2))

--- a/common/classify.py
+++ b/common/classify.py
@@ -183,9 +183,9 @@ class Classify:
         num_message_id_failed = 0
         total_completed = 0
 
-	self.d_name_per_feat = self.parse_feature_names()
+        self.d_name_per_feat = self.parse_feature_names()
         
-	for root, dirs, files in os.walk(self.email_path):
+        for root, dirs, files in os.walk(self.email_path):
             curr_time = time.time()
             if (curr_time - last_logged_time) > logging_interval * 60:
                 progress_logger.info('Exploring directory #{}'.format(num_senders_completed))
@@ -214,11 +214,11 @@ class Classify:
                     debug_logger.info("Size mismatch in {}".format(path))
                     num_message_id_failed += 1
                     test_mess_id = np.zeros(shape=(sample_size, 1), dtype="S200")
-		test_res = self.get_email_records(test_X, indx, root, test_indx, test_mess_id)
-		if test_res is not None:
+                test_res = self.get_email_records(test_X, indx, root, test_indx, test_mess_id)
+                if test_res is not None:
                     for email in test_res:
                         testSize += 1
-			sender = email.path
+                        sender = email.path
                         emailPath = email.path
                         probability = float(email.probability_phish)
                         message_ID = email.email_message_id.strip(" ")
@@ -247,7 +247,7 @@ class Classify:
 
         email_probabilities.close()
         self.num_phish, self.test_size = numPhish, testSize
-	low_volume_output = low_volume_top_10.createOutput()
+        low_volume_output = low_volume_top_10.createOutput()
         high_volume_output = high_volume_top_10.createOutput()
         output = [low_volume_output, high_volume_output]
 
@@ -279,8 +279,8 @@ class Classify:
 	    
             results.write(str(i) + ".json:\n")
             results.write("\tFrom: " + record.email_from + "\n")
-	    results.write("\tSubject: " + record.email_subject + "\n")
-	    results.write("\tTop 3 Detectors(in order): " + str(record.detector_contribution[0]) + ", " + str(record.detector_contribution[1]) + ", " + str(record.detector_contribution[2]) + "\n\n")
+            results.write("\tSubject: " + record.email_subject + "\n")
+            results.write("\tTop 3 Detectors(in order): " + str(record.detector_contribution[0]) + ", " + str(record.detector_contribution[1]) + ", " + str(record.detector_contribution[2]) + "\n\n")
             
             self.write_file(folder_name, i, email.header_dict, record.probability_phish, record.detector_contribution)
 	results.close()
@@ -289,7 +289,7 @@ class Classify:
         test_sample = test_X[test_indx]
         test_sample_minus_mean = test_sample.reshape((self.num_features, 1)) - col_averages
         product = np.multiply(test_sample_minus_mean.reshape(self.num_features), self.clf_coef)
-	d_contribution = defaultdict(float)
+        d_contribution = defaultdict(float)
         for i, d in enumerate(self.d_name_per_feat):
             d_contribution[d] += product[i]
         return OrderedDict(sorted(d_contribution.items(), key=lambda t: t[1], reverse=True))
@@ -337,31 +337,27 @@ class Classify:
             out.write(json.dumps(coefs, indent=2))
             out.write("Low Volume Senders: \n")
             out.write(str(output[0]) + "\n\n")
-	    out.write("High Volume Senders: \n")
-	    out.write(str(output[1]) + "\n\n")
-
-    
-def get_sender(self, path):
-        return path.split('/')[-2]
+            out.write("High Volume Senders: \n")
+            out.write(str(output[1]) + "\n\n")
 
 
     def get_email_records(self, test_X, indx, path, test_indx, test_mess_id):
-	sample_size = test_X.shape[0]
+        sample_size = test_X.shape[0]
         if sample_size == 0:
             return []
         
         prob_phish = self.clf.predict_proba(test_X)[:,1].reshape(sample_size,1)
         prob_phish[prob_phish < float(0.0001)] = 0
-	col_averages = np.mean(test_X, axis=0).reshape((self.num_features,1))	
-	
-	path = os.path.join(path, "legit_emails.log")
-	senderInbox = inbox.Inbox(root=path, sort=False)
+        col_averages = np.mean(test_X, axis=0).reshape((self.num_features,1))
+
+        path = os.path.join(path, "legit_emails.log")
+        senderInbox = inbox.Inbox(root=path, sort=False)
 
         records = []
         for i in range(sample_size):
             detector_contribution = self.get_detector_contribution(test_X, test_indx[i][0], col_averages)
             email = senderInbox[indx[i][0]]
-	    # make sure that message ID in disk for this email is the same as the corresponding test_mess_id passed in
-	    assert (email["MESSAGE-ID"] == test_mess_id[i][0].strip(" ") or (test_mess_id[i][0].strip(" ") == 'None' and type(email["MESSAGE-ID"]) == type(None)))
+            # make sure that message ID in disk for this email is the same as the corresponding test_mess_id passed in
+            assert (email["MESSAGE-ID"] == test_mess_id[i][0].strip(" ") or (test_mess_id[i][0].strip(" ") == 'None' and type(email["MESSAGE-ID"]) == type(None)))
             records.append(ResultRecord(path, indx[i][0], prob_phish[i][0], test_indx[i][0], detector_contribution, email))
         return records 

--- a/common/classify.py
+++ b/common/classify.py
@@ -281,7 +281,10 @@ class Classify:
 	    
             results.write(str(i) + ".json:\n")
             results.write("\tFrom: " + headers_dict["FROM"] + "\n")
-	    results.write("\tSubject: " + headers_dict["Subject"] + "\n")
+            subject = ""
+            if 'Subject' in headers_dict:
+		subject = headers_dict["Subject"]
+	    results.write("\tSubject: " + subject + "\n")
 	    results.write("\tTop 3 Detectors(in order): " + str(break_down_list[0][0]) + ", " + str(break_down_list[1][0]) + ", " + str(break_down_list[2][0]) + "\n\n")
             
             self.write_file(folder_name, i, headers_dict, row[PROBA_IND], break_down)

--- a/common/generate_features.py
+++ b/common/generate_features.py
@@ -142,7 +142,7 @@ class FeatureGenerator(object):
         test_data_matrix = np.zeros(shape=(self.num_emails - self.start_test_matrix_index, self.num_features), dtype='float64')
     
         test_mess_id = np.zeros(shape=(self.num_emails - self.start_test_matrix_index, 1), dtype='S200')
-        
+        test_email_index = np.zeros(shape=(self.num_emails - self.start_test_matrix_index, 1), dtype="int32")
         row_index = 0
         for i in range(self.start_test_matrix_index, self.num_emails):
             j = 0
@@ -160,10 +160,11 @@ class FeatureGenerator(object):
                 else:
                     test_data_matrix[row_index][j] = float(heuristic) if heuristic else 0.0
                     j += 1
+            test_email_index[row_index] = test_mbox[i].file_index
             row_index += 1
             for detector in self.detectors:
                 detector.update_sender_profile(test_mbox[i])
-        test_email_index = np.arange(self.start_test_matrix_index, self.num_emails)
+        # test_email_index = np.arange(self.start_test_matrix_index, self.num_emails)
         logs.Watchdog.reset()
         del logs.context['step']
         return test_data_matrix, test_email_index, test_mess_id

--- a/common/inbox.py
+++ b/common/inbox.py
@@ -8,12 +8,13 @@ import logging
 import logs
 
 class Inbox():
-	def __init__(self, root=None):
+	def __init__(self, root=None, sort=True):
 		self.emails = []
 		self.num_invalid_emails = 0
 		if root != None:
 			self.processEmails(root)
-			self.sort_emails()
+			if sort:
+				self.sort_emails()
 	def processEmails(self, root):
 		if os.path.isfile(root) and root.endswith(".log"):
 			logFileName = root

--- a/common/inbox.py
+++ b/common/inbox.py
@@ -23,10 +23,10 @@ class Inbox():
 					try:
 						header_tuples = eval(line)
 						self.emails.append(Email(i, header_tuples))
-						i += 1
 					except:
                                                 logs.RateLimitedLog("Invalid Email, during processEmails()", private=line)
 						self.num_invalid_emails += 1
+					i += 1
 		elif os.path.isdir(root):
 			for item in os.listdir(root):
 				subDir = os.path.join(root, item)

--- a/common/inbox.py
+++ b/common/inbox.py
@@ -18,10 +18,12 @@ class Inbox():
 		if os.path.isfile(root) and root.endswith(".log"):
 			logFileName = root
 			with open(logFileName, "r") as logFile:
+				i = 0
 				for line in logFile:
 					try:
 						header_tuples = eval(line)
-						self.emails.append(Email(header_tuples))	
+						self.emails.append(Email(i, header_tuples))
+						i += 1
 					except:
                                                 logs.RateLimitedLog("Invalid Email, during processEmails()", private=line)
 						self.num_invalid_emails += 1
@@ -55,7 +57,8 @@ class Inbox():
 		self.emails = sorted(self.emails, cmp=compare_emails)
 
 class Email():
-	def __init__(self, headers_arg=None):
+	def __init__(self, file_index=-1, headers_arg=None):
+		self.file_index = file_index
 		self.header_dict = {}
 		self.ordered_headers = []
 		if headers_arg != None:

--- a/common/priorityQueue.py
+++ b/common/priorityQueue.py
@@ -2,7 +2,7 @@ import bisect
 
 class PriorityQueue:
     def __init__(self, maxQueueSize):
-        # self._queue has a tuple with three values: (priority, self._id, and item)
+        # self._queue has a tuple with three values: (priority, self._id, and ResultRecord)
         # The priority is the probability and the item is an email represented by a numpy array
         self._queue = []
         self._size = 0
@@ -19,32 +19,32 @@ class PriorityQueue:
 
     # adds item to priority queue if among the top 10 emails with highest priority
     # only one email is maintained in the priority queue per sender
-    def push(self, item, priority):
+    def push(self, record, priority):
         # checks to see if this sender is already in that priority queue
         # if so, checks to see if probability should be updated
-        thisSender = item[0]
+        thisSender = record.path
         if thisSender in self._uniqueSenders:
             senderIndex = None
             for i in range(len(self._queue)):
-                if self._queue[i][2][0] == thisSender:
+                if self._queue[i][2].path == thisSender:
                     senderIndex = i
             if self._queue[senderIndex][0] < priority:
                 # update the priority of this item in the priority queue
                 self._queue.pop(senderIndex)
-                bisect.insort_left(self._queue,(priority, self._id, item))
+                bisect.insort_left(self._queue,(priority, self._id, record))
                 self._id += 1
             return
 
         # sender is not in priority queue
-        bisect.insort_left(self._queue,(priority, self._id, item))
+        bisect.insort_left(self._queue,(priority, self._id, record))
         self._id += 1
-        self._uniqueSenders.add(item[0])
+        self._uniqueSenders.add(record.path)
         self._size += 1
 
         # maintains the queue to have 10 elements or less
         if self._size > self.MAX_SIZE:
             popped = self._queue.pop(0)
-            self._uniqueSenders.remove(popped[2][0])
+            self._uniqueSenders.remove(popped[2].path)
             self._size -= 1
 
     # elements with a higher probability get popped off first
@@ -55,13 +55,13 @@ class PriorityQueue:
     def createOutput(self):
         results = []
         for item in self._queue[::-1]:
-            currentItem = item[2].tolist()
-            with open(currentItem[0]) as fp:
-                for i, line in enumerate(fp):
-                    if i == int(currentItem[1]):
-                        currentItem.append(line)
-                        break
-            results.append(currentItem)
+            record = item[2]
+            #with open(record.path) as fp:
+            #    for i, line in enumerate(fp):
+            #        if i == int(record.email_index):
+            #            currentItem.append(line)
+            #            break
+            results.append(record)
         return results
 
     def __str__(self):

--- a/common/resultRecord.py
+++ b/common/resultRecord.py
@@ -7,7 +7,10 @@ class ResultRecord:
 	self.message_id = mess_id
 	self.detector_contribution = detector_contribution.items()
 	self.all_headers = all_headers
-	self.email_from = self.all_headers["FROM"]
+	from_header = ""
+	if "FROMM" in self.all_headers:
+	    from_header = self.all_headers["FROM"]
+        self.email_from = from_header
 	subject = ""
 	if "SUBJECT" in self.all_headers:
 	    subject = self.all_headers["SUBJECT"]

--- a/common/resultRecord.py
+++ b/common/resultRecord.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 class ResultRecord:
     def __init__(self, path, email_index, prob_phish, test_index, mess_id, detector_contribution, all_headers):
 	self.path = path
@@ -14,46 +12,6 @@ class ResultRecord:
 	if "SUBJECT" in self.all_headers:
 	    subject = self.all_headers["SUBJECT"]
 	self.email_subject = subject
-
-    # functionality moved to classify.py	
-    # returns a list of Result Record objects given a path and indx
-    def createRecords(test_X, indx, path, test_indx, test_mess_id):
-	sample_size = test_X.shape[0]
-	if sample_size == 0:
-	    return []
-	
-	path = os.path.join(path, "legit_emails.log")
-	prob_phish = self.clf.predict_proba(test_X)[:,1].reshape(sample_size,1)
-	prob_phish[prob_phish < float(0.0001)] = 0
-        
-	records = []
-	for i in range(sample_size):
-	    detector_contribution = get_detector_contribution(test_X, test_indx[i])
-	    records.append(ResultRecord(path, indx[i], prob_phish[i], test_indx[i], test_mess_id[i], detector_contribution, eval(get_email(path, indx[i]))))
-	return records
-    # functionality moved to classify.py
-    def get_detector_contribution(test_X, test_indx):
-        # Removing the ending "legit_emails.log" and adding "test.mat"
-        test_sample = test_X['test_data'][test_indx]
-        # get column averages
-        col_averages = np.mean(test_X['test_data'], axis=0).reshape((self.num_features,1))
-        test_sample_minus_mean = test_sample.reshape((self.num_features, 1)) - col_averages
-        product = np.multiply(test_sample_minus_mean.reshape(self.num_features), self.clf_coef)
-        d_contribution = {}
-        curr = None
-        for i, d in enumerate(self.d_name_per_feat):
-            if curr is None or d != curr:
-                curr = d
-                d_contribution[curr] = 0
-            d_contribution[curr] += product[i]
-        return OrderedDict(sorted(d_contribution.items(), key=lambda t: t[1], reverse=True))
-    
-    # fuctionality moved to classify.py
-    def get_email(path, email_index):
-	with open(path) as fp:
-	    for i, line in enumerate(fp):
-	        if i == email_index:
-		    return line
 
     def __str__(self):
         return str(self.all_headers)

--- a/common/resultRecord.py
+++ b/common/resultRecord.py
@@ -1,23 +1,23 @@
 class ResultRecord:
     def __init__(self, path, email_index, prob_phish, test_index, detector_contribution, email):
-	self.path = path
+        self.path = path
         self.email_index = email_index
-	self.probability_phish = prob_phish
-	self.test_index = test_index
-	self.detector_contribution = detector_contribution.items()
-	self.email = email
-	from_header = ""
-	if "FROM" in self.email:
-	    from_header = self.email["FROM"]
-	self.email_from = from_header
-	subject = ""
-	if "SUBJECT" in self.email:
-	    subject = self.email["SUBJECT"]
-	self.email_subject = subject
-	mess_id = ""
-	if "MESSAGE-ID" in self.email:
-	    mess_id = self.email["MESSAGE-ID"]
-	self.email_message_id = mess_id
+        self.probability_phish = prob_phish
+        self.test_index = test_index
+        self.detector_contribution = detector_contribution.items()
+        self.email = email
+        from_header = ""
+        if "FROM" in self.email:
+            from_header = self.email["FROM"]
+        self.email_from = from_header
+        subject = ""
+        if "SUBJECT" in self.email:
+            subject = self.email["SUBJECT"]
+        self.email_subject = subject
+        mess_id = ""
+        if "MESSAGE-ID" in self.email:
+            mess_id = self.email["MESSAGE-ID"]
+        self.email_message_id = mess_id
 
     def __str__(self):
         return str(self.email.header_dict)

--- a/common/resultRecord.py
+++ b/common/resultRecord.py
@@ -11,8 +11,8 @@ class ResultRecord:
 	self.all_headers = all_headers
 	self.email_from = self.all_headers["FROM"]
 	subject = ""
-	if "Subject" in self.all_headers:
-	    subject = self.all_headers["Subject"]
+	if "SUBJECT" in self.all_headers:
+	    subject = self.all_headers["SUBJECT"]
 	self.email_subject = subject
 
     # functionality moved to classify.py	

--- a/common/resultRecord.py
+++ b/common/resultRecord.py
@@ -8,9 +8,9 @@ class ResultRecord:
 	self.detector_contribution = detector_contribution.items()
 	self.all_headers = all_headers
 	from_header = ""
-	if "FROMM" in self.all_headers:
+	if "FROM" in self.all_headers:
 	    from_header = self.all_headers["FROM"]
-        self.email_from = from_header
+	self.email_from = from_header
 	subject = ""
 	if "SUBJECT" in self.all_headers:
 	    subject = self.all_headers["SUBJECT"]

--- a/common/resultRecord.py
+++ b/common/resultRecord.py
@@ -1,0 +1,62 @@
+import numpy as np
+
+class ResultRecord:
+    def __init__(self, path, email_index, prob_phish, test_index, mess_id, detector_contribution, all_headers):
+	self.path = path
+        self.email_index = email_index
+	self.probability_phish = prob_phish
+	self.test_index = test_index
+	self.message_id = mess_id
+	self.detector_contribution = detector_contribution.items()
+	self.all_headers = all_headers
+	self.email_from = self.all_headers["FROM"]
+	subject = ""
+	if "Subject" in self.all_headers:
+	    subject = self.all_headers["Subject"]
+	self.email_subject = subject
+
+    # functionality moved to classify.py	
+    # returns a list of Result Record objects given a path and indx
+    def createRecords(test_X, indx, path, test_indx, test_mess_id):
+	sample_size = test_X.shape[0]
+	if sample_size == 0:
+	    return []
+	
+	path = os.path.join(path, "legit_emails.log")
+	prob_phish = self.clf.predict_proba(test_X)[:,1].reshape(sample_size,1)
+	prob_phish[prob_phish < float(0.0001)] = 0
+        
+	records = []
+	for i in range(sample_size):
+	    detector_contribution = get_detector_contribution(test_X, test_indx[i])
+	    records.append(ResultRecord(path, indx[i], prob_phish[i], test_indx[i], test_mess_id[i], detector_contribution, eval(get_email(path, indx[i]))))
+	return records
+    # functionality moved to classify.py
+    def get_detector_contribution(test_X, test_indx):
+        # Removing the ending "legit_emails.log" and adding "test.mat"
+        test_sample = test_X['test_data'][test_indx]
+        # get column averages
+        col_averages = np.mean(test_X['test_data'], axis=0).reshape((self.num_features,1))
+        test_sample_minus_mean = test_sample.reshape((self.num_features, 1)) - col_averages
+        product = np.multiply(test_sample_minus_mean.reshape(self.num_features), self.clf_coef)
+        d_contribution = {}
+        curr = None
+        for i, d in enumerate(self.d_name_per_feat):
+            if curr is None or d != curr:
+                curr = d
+                d_contribution[curr] = 0
+            d_contribution[curr] += product[i]
+        return OrderedDict(sorted(d_contribution.items(), key=lambda t: t[1], reverse=True))
+    
+    # fuctionality moved to classify.py
+    def get_email(path, email_index):
+	with open(path) as fp:
+	    for i, line in enumerate(fp):
+	        if i == email_index:
+		    return line
+
+    def __str__(self):
+        return str(self.all_headers)
+
+    def __repr__(self):
+        return str(self.all_headers)

--- a/common/resultRecord.py
+++ b/common/resultRecord.py
@@ -1,23 +1,26 @@
 class ResultRecord:
-    def __init__(self, path, email_index, prob_phish, test_index, mess_id, detector_contribution, all_headers):
+    def __init__(self, path, email_index, prob_phish, test_index, detector_contribution, email):
 	self.path = path
         self.email_index = email_index
 	self.probability_phish = prob_phish
 	self.test_index = test_index
-	self.message_id = mess_id
 	self.detector_contribution = detector_contribution.items()
-	self.all_headers = all_headers
+	self.email = email
 	from_header = ""
-	if "FROM" in self.all_headers:
-	    from_header = self.all_headers["FROM"]
+	if "FROM" in self.email:
+	    from_header = self.email["FROM"]
 	self.email_from = from_header
 	subject = ""
-	if "SUBJECT" in self.all_headers:
-	    subject = self.all_headers["SUBJECT"]
+	if "SUBJECT" in self.email:
+	    subject = self.email["SUBJECT"]
 	self.email_subject = subject
+	mess_id = ""
+	if "MESSAGE-ID" in self.email:
+	    mess_id = self.email["MESSAGE-ID"]
+	self.email_message_id = mess_id
 
     def __str__(self):
-        return str(self.all_headers)
+        return str(self.email.header_dict)
 
     def __repr__(self):
-        return str(self.all_headers)
+        return str(self.email.header_dict)


### PR DESCRIPTION
The main change made to refactor classify.py is adding the method get_email_records. This method replaced output_phish_probabilities and returns a list of ResultRecord objects for a particular sender. ResultRecord objects contain all necessary information needed to output results to file in the classify functions, pretty_print and get_detector_contribution. A sender's emails are loaded into an Inbox object in get_email_records.