### PR TITLE
Additional detector: detect Apple and Microsoft email clients

### DIFF
--- a/common/config.yaml
+++ b/common/config.yaml
@@ -26,6 +26,7 @@ detectors:
     XMailerDetector:            1
     ReceivedHeadersDetector:    1
     DateFormatDetector:         1
+    MailClientDetector:         1
 
 #Parallel Settings
 parallel:                       0

--- a/common/feature_classes.py
+++ b/common/feature_classes.py
@@ -7,3 +7,4 @@ from timezone import DateTimezoneDetector
 from received_headers import ReceivedHeadersDetector
 from message_ID_format import MessageIdFormatDetector
 from xmailer import XMailerDetector
+from mailclient import MailClientDetector

--- a/common/mailclient.py
+++ b/common/mailclient.py
@@ -54,7 +54,7 @@ def infer_mailer(email):
     else:
         return 'other'
 
-def logprob(k, n)
+def logprob(k, n):
     '''log-transform of probability that next outcome is c, given
        that we've observed n previous outcomes and k of them were c.'''
     # Apply add-one Laplace smoothing to compute log

--- a/common/mailclient.py
+++ b/common/mailclient.py
@@ -33,8 +33,6 @@ def is_apple_mailer(email):
         return True
     return has_apple_msgid(email)
 
-# MS_HDRS = ['X-MimeOLE', 'X-MS-Attach', 'X-MS-TNEF-Correlator', 'Thread-Index', 'acceptlanguage', 'Accept-Language', 'Content-Language']
-
 def is_microsoft_mailer(email):
     if email['X-MimeOLE'] is not None:
         return True
@@ -56,11 +54,11 @@ def infer_mailer(email):
     else:
         return 'other'
 
-def logprob(k, n, ncategories):
+def logprob(k, n)
     '''log-transform of probability that next outcome is c, given
        that we've observed n previous outcomes and k of them were c.'''
     # Apply add-one Laplace smoothing to compute log
-    p = float(k+1) / float(n+ncategories)
+    p = float(k+1) / float(n+NUM_CATEGORIES)
     # log-transform
     return np.log((1.0/p) - 1.0)
 
@@ -96,8 +94,8 @@ class MailClientDetector(Detector):
         m = infer_mailer(phish)
         if prof.emails > 0 and prof.counts[m] == 0:
             fv[0] = 1.0
-            fv[1] = logprob(0, prof.emails, NUM_CATEGORIES)
-        fv[2] = logprob(prof.counts[m], prof.emails, NUM_CATEGORIES)
+            fv[1] = logprob(0, prof.emails)
+        fv[2] = logprob(prof.counts[m], prof.emails)
 
         return fv
 

--- a/common/mailclient.py
+++ b/common/mailclient.py
@@ -1,0 +1,107 @@
+from collections import defaultdict
+from collections import Counter
+from detector import Detector
+import numpy as np
+import re
+
+APPLE_MSG_ID = re.compile('<[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}@')
+
+def has_apple_msgid(email):
+    msgid = email['Message-ID']
+    if msgid is None or not APPLE_MSG_ID.match(msgid):
+        return False
+    ua = email['User-Agent']
+    if ua is not None and 'microsoft' in ua.lower():
+        # Special case: if the mail client claims to be Microsoft,
+        # then we don't override that.
+        # There are known cases where Microsoft Outlook for Mac OS X
+        # generates message ID's with the above format.
+        return False
+    return True
+
+def is_apple_mailer(email):
+    xm = email['X-Mailer']
+    if xm is not None:
+        xm = xm.lower()
+        if 'apple' in xm or 'ipad' in xm or 'iphone' in xm:
+            return True
+    mv = email['Mime-Version']
+    if mv is not None and 'apple' in mv.lower():
+        return True
+    ct = email['Content-Type']
+    if ct is not None and 'apple' in ct.lower():
+        return True
+    return has_apple_msgid(email)
+
+# MS_HDRS = ['X-MimeOLE', 'X-MS-Attach', 'X-MS-TNEF-Correlator', 'Thread-Index', 'acceptlanguage', 'Accept-Language', 'Content-Language']
+
+def is_microsoft_mailer(email):
+    if email['X-MimeOLE'] is not None:
+        return True
+    xm = email['X-Mailer']
+    if xm is not None and 'microsoft' in xm.lower():
+        return True
+    ua = email['User-Agent']
+    if ua is not None and 'microsoft' in ua.lower():
+        return True
+    return False
+
+NUM_CATEGORIES = 3
+
+def infer_mailer(email):
+    if is_apple_mailer(email):
+        return 'apple'
+    elif is_microsoft_mailer(email):
+        return 'microsoft'
+    else:
+        return 'other'
+
+def logprob(k, n, ncategories):
+    '''log-transform of probability that next outcome is c, given
+       that we've observed n previous outcomes and k of them were c.'''
+    # Apply add-one Laplace smoothing to compute log
+    p = float(k+1) / float(n+ncategories)
+    # log-transform
+    return np.log((1.0/p) - 1.0)
+
+class Profile(object):
+    def __init__(self):
+        self.emails = 0
+        self.counts = Counter()
+
+class MailClientDetector(Detector):
+    NUM_HEURISTICS = 3
+
+    def __init__(self, inbox):
+        self.inbox = inbox
+        self.sender_profile = defaultdict(Profile)
+        self._already_created = False
+
+    def update_sender_profile(self, email):
+        curr_sender = self.extract_from(email)
+        if curr_sender:
+            prof = self.sender_profile[curr_sender]
+            prof.emails += 1
+            m = infer_mailer(email)
+            prof.counts[m] += 1
+
+    def classify(self, phish):
+        fv = [0.0, 0.0, 0.0]
+
+        curr_sender = self.extract_from(phish)
+        if not curr_sender or not curr_sender in self.sender_profile:
+            return fv
+        prof = self.sender_profile[curr_sender]
+
+        m = infer_mailer(phish)
+        if prof.emails > 0 and prof.counts[m] == 0:
+            fv[0] = 1.0
+            fv[1] = logprob(0, prof.emails, NUM_CATEGORIES)
+        fv[2] = logprob(prof.counts[m], prof.emails, NUM_CATEGORIES)
+
+        return fv
+
+    def modify_phish(self, phish, msg):
+        phish["Message-ID"] = msg["Message-ID"]
+        phish["X-Mailer"] = msg["X-Mailer"]
+        return phish

--- a/common/mailclient.py
+++ b/common/mailclient.py
@@ -44,11 +44,27 @@ def is_microsoft_mailer(email):
         return True
     return False
 
-NUM_CATEGORIES = 3
+ANDROID_MSG_ID1 = re.compile('<[a-z0-9]{24}\.[0-9]{13}@')
+ANDROID_MSG_ID2 = re.compile('<.*@email.android.com>')
+ANDROID_CT = re.compile('boundary="--_com.android.email_[0-9]{14,16}"')
+
+def is_android(email):
+    msgid = email['Message-ID']
+    ct = email['Content-Type']
+    if msgid is not None:
+        if ANDROID_MSG_ID1.match(msgid) or ANDROID_MSG_ID2.match(msgid):
+            return True
+    if ct is not None and ANDROID_CT.search(ct):
+        return True
+    return False
+
+NUM_CATEGORIES = 4
 
 def infer_mailer(email):
     if is_apple_mailer(email):
         return 'apple'
+    elif is_android(email):
+        return 'android'
     elif is_microsoft_mailer(email):
         return 'microsoft'
     else:


### PR DESCRIPTION
Use various heuristics to detect Apple and Microsoft email clients, and build a detector in this way.

Offers only a very small improvement to accuracy.  Below is a before-and-after comparison on my test mbox.

Baseline (without this PR):

    Confusion matrix - True positives: 6027.0, False positives: 33.0, False negatives: 4861.0, True negatives: 10855.0
    False positive rate: 0.00303085966201
    False negative rate: 0.446454812638

With this change:

    Confusion matrix - True positives: 6057.0, False positives: 29.0, False negatives: 4831.0, True negatives: 10859.0
    False positive rate: 0.00266348273328
    False negative rate: 0.443699485672


