### PR TITLE
Check order of headers

### DIFF
--- a/common/config.yaml
+++ b/common/config.yaml
@@ -26,6 +26,7 @@ detectors:
     XMailerDetector:            1
     ReceivedHeadersDetector:    1
     DateFormatDetector:         1
+    HdrOrderDetector:           1
 
 #Parallel Settings
 parallel:                       0

--- a/common/feature_classes.py
+++ b/common/feature_classes.py
@@ -7,3 +7,4 @@ from timezone import DateTimezoneDetector
 from received_headers import ReceivedHeadersDetector
 from message_ID_format import MessageIdFormatDetector
 from xmailer import XMailerDetector
+from hdrorder import HdrOrderDetector

--- a/common/hdrorder.py
+++ b/common/hdrorder.py
@@ -1,0 +1,62 @@
+from collections import defaultdict
+from collections import Counter
+from detector import Detector
+import numpy as np
+import re
+
+hdrmap = {'from': 'f', 'subject': 's', 'to': 't', 'date': 'd',
+          'message-id': 'm', 'mime-version': 'v', 'content-type': 'y',
+          'x-mailer': 'x'}
+
+def get_order(msg):
+    l = [hdrmap[h.lower()] for h in msg.keys() if h.lower() in hdrmap]
+    return ''.join(l)
+
+def logprob(k, n, possible_outcomes):
+    '''log-transform of probability that next outcome is c, given
+       that we've observed n previous outcomes and k of them were c.'''
+    # Apply add-one Laplace smoothing to compute log
+    p = float(k+1) / float(n+possible_outcomes)
+    # log-transform
+    return np.log((1.0/p) - 1.0)
+
+class Profile(object):
+    def __init__(self):
+        self.emails = 0
+        self.counts = Counter()
+
+class HdrOrderDetector(Detector):
+    NUM_HEURISTICS = 3
+
+    def __init__(self, inbox):
+        self.inbox = inbox
+        self.sender_profile = defaultdict(Profile)
+        self._already_created = False
+
+    def update_sender_profile(self, email):
+        curr_sender = self.extract_from(email)
+        if curr_sender:
+            prof = self.sender_profile[curr_sender]
+            prof.emails += 1
+            order = get_order(email)
+            prof.counts[order] += 1
+
+    def classify(self, phish):
+        fv = [0.0, 0.0, 0.0]
+
+        curr_sender = self.extract_from(phish)
+        if not curr_sender or not curr_sender in self.sender_profile:
+            return fv
+        prof = self.sender_profile[curr_sender]
+
+        order = get_order(phish)
+        if prof.emails > 0 and prof.counts[order] == 0:
+            fv[0] = 1.0
+            fv[1] = logprob(0, prof.emails, len(prof.counts)+1)
+        if prof.emails > 0:
+            fv[2] = logprob(prof.counts[order], prof.emails, len(prof.counts)+1)
+        return fv
+
+    def modify_phish(self, phish, msg):
+        phish["Date"] = msg["Date"]
+        return phish


### PR DESCRIPTION
Adds a detector that uses the order of 8 basic headers that are nearly always present: From, Subject, To, Date, Message-ID, Mime-Version, Content-Type, X-Mailer.  This is a simplified version of OrderOfHeadersDetector.

On my test mbox, this offers only a tiny improvement, if any:

Baseline (on master; without this pull request):

    Confusion matrix - True positives: 6027.0, False positives: 33.0, False negatives: 4861.0, True negatives: 10855.0
    False positive rate: 0.00303085966201
    False negative rate: 0.446454812638

With this detector (with this pull request):

    Confusion matrix - True positives: 6011.0, False positives: 31.0, False negatives: 4877.0, True negatives: 10857.0
    False positive rate: 0.00284717119765
    False negative rate: 0.447924320353
