### PR TITLE
Split by time

### DIFF
--- a/broScripts/parse_pcap_mbox.py
+++ b/broScripts/parse_pcap_mbox.py
@@ -146,7 +146,7 @@ try:
     progress_logger.info('Done.  Created #{} directories.'.format(dir_num))
     senders_seen.close()
 
-    shuffle_command = "gshuf {} --output={}".format(SENDERS_FILE, SENDERS_FILE)
+    shuffle_command = "shuf {} --output={}".format(SENDERS_FILE, SENDERS_FILE)
     progress_logger.info("Executing: {}".format(shuffle_command))
     os.system(shuffle_command)
 

--- a/broScripts/parse_pcap_mbox.py
+++ b/broScripts/parse_pcap_mbox.py
@@ -146,7 +146,7 @@ try:
     progress_logger.info('Done.  Created #{} directories.'.format(dir_num))
     senders_seen.close()
 
-    shuffle_command = "shuf {} --output={}".format(SENDERS_FILE, SENDERS_FILE)
+    shuffle_command = "gshuf {} --output={}".format(SENDERS_FILE, SENDERS_FILE)
     progress_logger.info("Executing: {}".format(shuffle_command))
     os.system(shuffle_command)
 

--- a/common/classify.py
+++ b/common/classify.py
@@ -94,6 +94,11 @@ class Classify:
         self.X = X
         self.Y = Y
         self.num_features = X.shape[1]
+
+        num_data_matrix = len(self.Y)
+        num_phish = np.count_nonzero(self.Y == 1)
+        num_legit = np.count_nonzero(self.Y == 0)
+        progress_logger.info("{} samples in data matrix, {} legit, {} phish".format(num_data_matrix, num_legit, num_phish))
         # Save training data matrix and training labels to training_data.npz.
         # np.savez("training_data", X=np.vstack([self.feature_names, self.X]), Y=self.Y)
         np.savez("training_data", X=self.X, Y=self.Y)

--- a/common/config.yaml
+++ b/common/config.yaml
@@ -2,10 +2,25 @@
 
 #Data and Test Matrix Configurations
 root_dir:                       ../broScripts/output
+use_name_in_from:               1
+
+#Config for splits
+use_percentage:                 1
+
+#if use_percentage = 1
 sender_profile_percentage:      0.1
 data_matrix_percentage:         0.2
 test_matrix_percentage:         0.7
-use_name_in_from:               1
+
+#if use_percentage = 0
+#Format: Month Day Year
+#interval = [start, end)
+sender_profile_start_time:      "March 5 2014"
+sender_profile_end_time:        "March 9 2014"
+train_start_time:               "March 9 2014"
+train_end_time:                 "September 27 2014"
+test_start_time:                "September 27 2014"
+test_end_time:                  "February 7 2015"
 
 #Model Training and Classification Settings
 weights:

--- a/common/detector.py
+++ b/common/detector.py
@@ -23,17 +23,17 @@ class Detector(object):
         """
         return
 
-    def create_sender_profile(self, num_samples):
+    def create_sender_profile(self, sample_indeces):
         """Creates sender to profile map.
 
         Keyword arguments:
-        num_samples -- number of samples to train sender profile on.
+        sample_indeces -- indeces of sample emails to train sender profile on.
 
         Sets self.sender_profile to a dictionary mapping senders to profiles.
         """
         if self._already_created:
             raise RuntimeError("Tried to call create_sender_profile() twice on same detector")
-        for i in range(num_samples):
+        for i in sample_indeces:
             email = self.inbox[i]
             self.update_sender_profile(email)
         self._already_created = True

--- a/common/generate_features.py
+++ b/common/generate_features.py
@@ -46,7 +46,7 @@ class FeatureGenerator(object):
                  sender_profile_time_interval,
                  train_time_interval,
                  test_time_interval,
-                 use_percentages,
+                 use_percentage,
                  features):
 
         self.output_directory = output_directory
@@ -56,7 +56,7 @@ class FeatureGenerator(object):
         self.sender_profile_time_interval = sender_profile_time_interval
         self.train_time_interval = train_time_interval
         self.test_time_interval = test_time_interval
-        self.use_percentages = use_percentages
+        self.use_percentage = use_percentage
 
         self.do_generate_data_matrix = False
         self.do_generate_test_matrix = False
@@ -70,7 +70,7 @@ class FeatureGenerator(object):
         self.phish_emails = inbox.Inbox(phish_filename)
         self.num_emails = len(self.emails)
 
-        if self.use_percentages:
+        if self.use_percentage:
 
             #Convert from percentages to number of emails in each
             if self.num_emails <= 1:

--- a/common/generate_features.py
+++ b/common/generate_features.py
@@ -192,8 +192,6 @@ class FeatureGenerator(object):
                         data_matrix[legit_row][j] = float(heuristic) if heuristic else 0.0
                         j += 1
                 legit_row += 1
-                for detector in self.detectors:
-                    detector.update_sender_profile(inbox[i])
             if indeces_index < len(self.data_matrix_phish_indeces):
                 i = self.data_matrix_phish_indeces[indeces_index]
                 j = 0
@@ -207,6 +205,10 @@ class FeatureGenerator(object):
                         data_matrix[phish_row][j] = float(heuristic) if heuristic else 0.0
                         j += 1
                 phish_row += 1
+            if indeces_index < len(self.data_matrix_indeces):
+                i = self.data_matrix_indeces[indeces_index]
+                for detector in self.detectors:
+                    detector.update_sender_profile(inbox[i])
         assert legit_row == self.data_matrix_num_emails
         assert phish_row == self.data_matrix_num_emails + self.data_matrix_num_phish_emails
         logs.Watchdog.reset()

--- a/common/generate_features.py
+++ b/common/generate_features.py
@@ -178,32 +178,35 @@ class FeatureGenerator(object):
     
         legit_row = 0
         phish_row = self.data_matrix_num_emails
-        for i in self.data_matrix_indeces:
-            j = 0
-            for detector in self.detectors:
-                heuristic = detector.classify(inbox[i])
-                if type(heuristic) == list:
-                    for h in heuristic:
-                        data_matrix[legit_row][j] = float(h)
+        for indeces_index in range(max(len(self.data_matrix_indeces), len(self.data_matrix_phish_indeces))):
+            if indeces_index < len(self.data_matrix_indeces):
+                i = self.data_matrix_indeces[indeces_index]
+                j = 0
+                for detector in self.detectors:
+                    heuristic = detector.classify(inbox[i])
+                    if type(heuristic) == list:
+                        for h in heuristic:
+                            data_matrix[legit_row][j] = float(h)
+                            j += 1
+                    else:
+                        data_matrix[legit_row][j] = float(heuristic) if heuristic else 0.0
                         j += 1
-                else:
-                    data_matrix[legit_row][j] = float(heuristic) if heuristic else 0.0
-                    j += 1
-            legit_row += 1
-        for i in self.data_matrix_phish_indeces:
-            j = 0
-            for detector in self.detectors:
-                heuristic = detector.classify(phish_inbox[i])
-                if type(heuristic) == list:
-                    for h in heuristic:
-                        data_matrix[phish_row][j] = float(h)
+                legit_row += 1
+                for detector in self.detectors:
+                    detector.update_sender_profile(inbox[i])
+            if indeces_index < len(self.data_matrix_phish_indeces):
+                i = self.data_matrix_phish_indeces[indeces_index]
+                j = 0
+                for detector in self.detectors:
+                    heuristic = detector.classify(phish_inbox[i])
+                    if type(heuristic) == list:
+                        for h in heuristic:
+                            data_matrix[phish_row][j] = float(h)
+                            j += 1
+                    else:
+                        data_matrix[phish_row][j] = float(heuristic) if heuristic else 0.0
                         j += 1
-                else:
-                    data_matrix[phish_row][j] = float(heuristic) if heuristic else 0.0
-                    j += 1
-            phish_row += 1
-            for detector in self.detectors:
-                detector.update_sender_profile(inbox[i])
+                phish_row += 1
         assert legit_row == self.data_matrix_num_emails
         assert phish_row == self.data_matrix_num_emails + self.data_matrix_num_phish_emails
         logs.Watchdog.reset()

--- a/common/order_of_headers.py
+++ b/common/order_of_headers.py
@@ -95,8 +95,8 @@ class OrderOfHeaderDetector(Detector):
             self.sender_profile[sender].add_order(order)
             self.emails_with_sender += 1
 
-    def create_sender_profile(self, num_samples):
-        for i in range(num_samples):
+    def create_sender_profile(self, sample_indeces):
+        for i in sample_indeces:
             email = self.inbox[i]
             self.update_sender_profile(email)
         self._debug_large_senders()

--- a/common/phish_detector.py
+++ b/common/phish_detector.py
@@ -195,12 +195,32 @@ class PhishDetector(object):
         regular_path = os.path.join(directory, self.regular_filename)
         phish_path = os.path.join(directory, self.phish_filename)
 
+
+        use_percentages = True
+
+        sender_profile_time_begin = 1
+        sender_profile_time_end = 1
+        train_time_begin = 1
+        train_time_end = 1
+        test_time_begin = 1
+        test_time_end = 1
+
+        sender_profile_time_interval = (sender_profile_time_begin, sender_profile_time_end)
+        train_time_interval = (train_time_begin, train_time_end)
+        test_time_interval = (test_time_begin, test_time_end)
+
+
+
         feature_generator = FeatureGenerator(directory,
                                              regular_path,
                                              phish_path,
                                              self.sender_profile_percentage,
                                              self.data_matrix_percentage,
                                              self.test_matrix_percentage,
+                                             sender_profile_time_interval,
+                                             train_time_interval,
+                                             test_time_interval,
+                                             use_percentages,
                                              self.detectors
                                             )
 

--- a/common/phish_detector.py
+++ b/common/phish_detector.py
@@ -196,14 +196,14 @@ class PhishDetector(object):
         phish_path = os.path.join(directory, self.phish_filename)
 
 
-        use_percentages = True
+        use_percentages = False
 
-        sender_profile_time_begin = 1
-        sender_profile_time_end = 1
-        train_time_begin = 1
-        train_time_end = 1
-        test_time_begin = 1
-        test_time_end = 1
+        sender_profile_time_begin = 1394061604
+        sender_profile_time_end = 1394290492
+        train_time_begin = 1394290492
+        train_time_end = 1411705202
+        test_time_begin = 1412310032
+        test_time_end = 1423199989 + 1
 
         sender_profile_time_interval = (sender_profile_time_begin, sender_profile_time_end)
         train_time_interval = (train_time_begin, train_time_end)

--- a/common/phish_detector.py
+++ b/common/phish_detector.py
@@ -6,6 +6,7 @@ from multiprocessing import Pool
 import os
 import subprocess
 import time
+import calendar
 import traceback
 
 import yaml
@@ -154,6 +155,13 @@ class PhishDetector(object):
             'root_dir',
             'regular_filename',
             'phish_filename',
+            'use_percentage',
+            'sender_profile_start_time',
+            'sender_profile_end_time',
+            'train_start_time',
+            'train_end_time',
+            'test_start_time',
+            'test_end_time',
             'sender_profile_percentage',
             'data_matrix_percentage',
             'test_matrix_percentage',
@@ -171,8 +179,8 @@ class PhishDetector(object):
             'logging_interval',
             'memlog_gen_features_frequency',
             'memlog_classify_frequency', 
-	    'senders',
-	    'recipients'
+	        'senders',
+	        'recipients'
         ]
 
         try:
@@ -191,23 +199,22 @@ class PhishDetector(object):
         self.root_dir = os.path.abspath(self.root_dir)
         Lookup.initialize(offline=self.offline)
 
+        if not self.use_percentage:
+            self.sender_profile_start_time = calendar.timegm(time.strptime(self.sender_profile_start_time, "%B %d %Y"))
+            self.sender_profile_end_time = calendar.timegm(time.strptime(self.sender_profile_end_time, "%B %d %Y"))
+            self.train_start_time = calendar.timegm(time.strptime(self.train_start_time, "%B %d %Y"))
+            self.train_end_time = calendar.timegm(time.strptime(self.train_end_time, "%B %d %Y"))
+            self.test_start_time = calendar.timegm(time.strptime(self.test_start_time, "%B %d %Y"))
+            self.test_end_time = calendar.timegm(time.strptime(self.test_end_time, "%B %d %Y"))
+
+
     def prep_features(self, directory):   
         regular_path = os.path.join(directory, self.regular_filename)
         phish_path = os.path.join(directory, self.phish_filename)
 
-
-        use_percentages = False
-
-        sender_profile_time_begin = 1394061604
-        sender_profile_time_end = 1394290492
-        train_time_begin = 1394290492
-        train_time_end = 1411705202
-        test_time_begin = 1412310032
-        test_time_end = 1423199989 + 1
-
-        sender_profile_time_interval = (sender_profile_time_begin, sender_profile_time_end)
-        train_time_interval = (train_time_begin, train_time_end)
-        test_time_interval = (test_time_begin, test_time_end)
+        sender_profile_time_interval = (self.sender_profile_start_time, self.sender_profile_end_time)
+        train_time_interval = (self.train_start_time, self.train_end_time)
+        test_time_interval = (self.test_start_time, self.test_end_time)
 
 
 
@@ -220,7 +227,7 @@ class PhishDetector(object):
                                              sender_profile_time_interval,
                                              train_time_interval,
                                              test_time_interval,
-                                             use_percentages,
+                                             self.use_percentage,
                                              self.detectors
                                             )
 

--- a/common/received_headers.py
+++ b/common/received_headers.py
@@ -79,8 +79,8 @@ class ReceivedHeadersDetector(Detector):
         if sender:
             self.sender_profile[sender].add_mailpath(mailpath)
 
-    def create_sender_profile(self, num_samples):
-        for i in range(num_samples):
+    def create_sender_profile(self, sample_indeces):
+        for i in sample_indeces:
             email = self.inbox[i]
             self.update_sender_profile(email)
         self._log_large_profiles()


### PR DESCRIPTION
Implements option to split emails into sender profile/data matrix/test matrix by specified time boundaries (through the config). Implements #137.

Questions about this design:
1. If the date from an email has no parseable date, should we put it in the test set? This is currently what happens.
2. What about emails not in any specified range? I currently don't use them at all.
3. For phishing emails, I notice these are only used in the data matrix (not the test matrix or sender profile). For this, I'm wondering if I should simply use the time interval as specified by the interval used for the legit emails for the data matrix? This is what I currently do. If we decide on something else, hopefully this implementation is robust enough to change it easily.
