### PR TITLE
Deduplicate senders

### DIFF
--- a/common/classify.py
+++ b/common/classify.py
@@ -200,7 +200,6 @@ class Classify:
 	top_emails = PriorityQueue(self.bucket_size)
 
         numPhish, testSize = 0, 0
-        numEmails4Sender = {}
 
         logging_interval = 60 # TODO(matthew): Move to config.yaml
         progress_logger.info("Starting to test on data.")
@@ -264,18 +263,6 @@ class Classify:
                             if probability > 0.5:
                                 numPhish += 1
 
-                            # caches the num_emails value for each sender
-                            #if sender not in numEmails4Sender:
-                            #    num_emails = sum(1 for line in open(emailPath))
-                            #    numEmails4Sender[sender] = num_emails
-                            #else:
-                            #    num_emails = numEmails4Sender[sender]
-
-                            # checks which priority queue to add item to
-                            #if num_emails < self.bucket_thres:
-                            #    low_volume_top_10.push(email, probability)
-                            #else:
-                            #    high_volume_top_10.push(email, probability)
 			    top_emails.push(email, probability)
                             # writes an email's message ID and phish probability to a file
                             email_probabilities.write(message_ID + "," + str(probability) + "\n")
@@ -287,14 +274,10 @@ class Classify:
         email_probabilities.close()
         self.num_phish, self.test_size = numPhish, testSize
         top_emails_output = top_emails.createOutput()
-	#low_volume_output = low_volume_top_10.createOutput()
-        #high_volume_output = high_volume_top_10.createOutput()
         output = [top_emails_output]
 
         # DEBUG information - don't print to main log
         # debug_logger.info(pp.pformat(output))
-        #self.pretty_print(low_volume_output, "low_volume")
-        #self.pretty_print(high_volume_output, "high_volume")
 	self.pretty_print(top_emails_output, "all_emails")
         self.write_summary_output(output)
 

--- a/common/classify.py
+++ b/common/classify.py
@@ -194,8 +194,10 @@ class Classify:
 
         # creates this file in common/output
         email_probabilities = open(os.path.join("output", "email_probabilities.txt"), "w")
-        low_volume_top_10 = PriorityQueue(self.bucket_size)
-        high_volume_top_10 = PriorityQueue(self.bucket_size)
+        #low_volume_top_10 = PriorityQueue(self.bucket_size)
+        #high_volume_top_10 = PriorityQueue(self.bucket_size)
+	
+	top_emails = PriorityQueue(self.bucket_size)
 
         numPhish, testSize = 0, 0
         numEmails4Sender = {}
@@ -263,18 +265,18 @@ class Classify:
                                 numPhish += 1
 
                             # caches the num_emails value for each sender
-                            if sender not in numEmails4Sender:
-                                num_emails = sum(1 for line in open(emailPath))
-                                numEmails4Sender[sender] = num_emails
-                            else:
-                                num_emails = numEmails4Sender[sender]
+                            #if sender not in numEmails4Sender:
+                            #    num_emails = sum(1 for line in open(emailPath))
+                            #    numEmails4Sender[sender] = num_emails
+                            #else:
+                            #    num_emails = numEmails4Sender[sender]
 
                             # checks which priority queue to add item to
-                            if num_emails < self.bucket_thres:
-                                low_volume_top_10.push(email, probability)
-                            else:
-                                high_volume_top_10.push(email, probability)
-
+                            #if num_emails < self.bucket_thres:
+                            #    low_volume_top_10.push(email, probability)
+                            #else:
+                            #    high_volume_top_10.push(email, probability)
+			    top_emails.push(email, probability)
                             # writes an email's message ID and phish probability to a file
                             email_probabilities.write(message_ID + "," + str(probability) + "\n")
                     total_completed += 1
@@ -284,14 +286,16 @@ class Classify:
 
         email_probabilities.close()
         self.num_phish, self.test_size = numPhish, testSize
-        low_volume_output = low_volume_top_10.createOutput()
-        high_volume_output = high_volume_top_10.createOutput()
-        output = [low_volume_output, high_volume_output]
+        top_emails_output = top_emails.createOutput()
+	#low_volume_output = low_volume_top_10.createOutput()
+        #high_volume_output = high_volume_top_10.createOutput()
+        output = [top_emails_output]
 
         # DEBUG information - don't print to main log
         # debug_logger.info(pp.pformat(output))
-        self.pretty_print(low_volume_output, "low_volume")
-        self.pretty_print(high_volume_output, "high_volume")
+        #self.pretty_print(low_volume_output, "low_volume")
+        #self.pretty_print(high_volume_output, "high_volume")
+	self.pretty_print(top_emails_output, "all_emails")
         self.write_summary_output(output)
 
         end_time = time.time()

--- a/common/priorityQueue.py
+++ b/common/priorityQueue.py
@@ -11,7 +11,7 @@ class PriorityQueue:
 	
 
         # a unique sender is determined by the path to the sender's emails
-        self._uniqueSenders = set([])
+        #self._uniqueSenders = set([])
 
     def getLength(self):
         return self._size
@@ -22,29 +22,29 @@ class PriorityQueue:
     def push(self, record, priority):
         # checks to see if this sender is already in that priority queue
         # if so, checks to see if probability should be updated
-        thisSender = record.path
-        if thisSender in self._uniqueSenders:
-            senderIndex = None
-            for i in range(len(self._queue)):
-                if self._queue[i][2].path == thisSender:
-                    senderIndex = i
-            if self._queue[senderIndex][0] < priority:
+        #thisSender = record.path
+        #if thisSender in self._uniqueSenders:
+        #    senderIndex = None
+        #    for i in range(len(self._queue)):
+        #        if self._queue[i][2].path == thisSender:
+        #            senderIndex = i
+        #    if self._queue[senderIndex][0] < priority:
                 # update the priority of this item in the priority queue
-                self._queue.pop(senderIndex)
-                bisect.insort_left(self._queue,(priority, self._id, record))
-                self._id += 1
-            return
+        #        self._queue.pop(senderIndex)
+        #        bisect.insort_left(self._queue,(priority, self._id, record))
+        #        self._id += 1
+        #    return
 
         # sender is not in priority queue
         bisect.insort_left(self._queue,(priority, self._id, record))
         self._id += 1
-        self._uniqueSenders.add(record.path)
+        #self._uniqueSenders.add(record.path)
         self._size += 1
 
         # maintains the queue to have 10 elements or less
         if self._size > self.MAX_SIZE:
             popped = self._queue.pop(0)
-            self._uniqueSenders.remove(popped[2].path)
+            #self._uniqueSenders.remove(popped[2].path)
             self._size -= 1
 
     # elements with a higher probability get popped off first

--- a/common/priorityQueue.py
+++ b/common/priorityQueue.py
@@ -11,7 +11,6 @@ class PriorityQueue:
 	
 
         # a unique sender is determined by the path to the sender's emails
-        #self._uniqueSenders = set([])
 
     def getLength(self):
         return self._size
@@ -20,31 +19,13 @@ class PriorityQueue:
     # adds item to priority queue if among the top 10 emails with highest priority
     # only one email is maintained in the priority queue per sender
     def push(self, record, priority):
-        # checks to see if this sender is already in that priority queue
-        # if so, checks to see if probability should be updated
-        #thisSender = record.path
-        #if thisSender in self._uniqueSenders:
-        #    senderIndex = None
-        #    for i in range(len(self._queue)):
-        #        if self._queue[i][2].path == thisSender:
-        #            senderIndex = i
-        #    if self._queue[senderIndex][0] < priority:
-                # update the priority of this item in the priority queue
-        #        self._queue.pop(senderIndex)
-        #        bisect.insort_left(self._queue,(priority, self._id, record))
-        #        self._id += 1
-        #    return
-
-        # sender is not in priority queue
         bisect.insort_left(self._queue,(priority, self._id, record))
         self._id += 1
-        #self._uniqueSenders.add(record.path)
         self._size += 1
 
         # maintains the queue to have 10 elements or less
         if self._size > self.MAX_SIZE:
             popped = self._queue.pop(0)
-            #self._uniqueSenders.remove(popped[2].path)
             self._size -= 1
 
     # elements with a higher probability get popped off first
@@ -56,11 +37,6 @@ class PriorityQueue:
         results = []
         for item in self._queue[::-1]:
             record = item[2]
-            #with open(record.path) as fp:
-            #    for i, line in enumerate(fp):
-            #        if i == int(record.email_index):
-            #            currentItem.append(line)
-            #            break
             results.append(record)
         return results
 


### PR DESCRIPTION
Below are the main changes made in this PR:

- Rather than having two output folders (low_volume and high_volume) with sender information, only have one folder (all_emails) that does not distinguish between the number of emails a sender has sent.
- Instead of storing one email per sender in common/output, store the emails with highest phish probability regardless of whether some emails are from the same sender. 